### PR TITLE
CI: run the test suite and a build, on a portable test runner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Normalise to LF in the index and in every working tree.
+#
+# tests/spot-locations-directory.test.mjs compares supabase/migrations/0004 to the
+# output of scripts/seed-locations.mjs byte-for-byte. Without this file, a checkout
+# under core.autocrlf=true rewrites the .sql to CRLF while the generator emits LF,
+# so that gate fails on Windows for a reason that has nothing to do with the SQL.
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.avif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: ci
+
+# The correctness gates. Until this workflow existed, CI ran CodeQL, tsc, npm audit
+# and gitleaks — but never the test suite and never a build, so a change that broke
+# every test or broke the build merged green (issue #5).
+#
+# `npm test` used to be a PowerShell one-liner and could not have run here at all;
+# it is now scripts/run-tests.mjs, which spawns each tests/*.test.mjs on any platform.
+
+on:
+  push:
+    branches: [main, 'codex/**']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # tests/live-rls.test.mjs skips itself when .env.preview.local is absent, so the
+      # suite is green here without database credentials and never targets production.
+      - name: Run test suite
+        run: npm run test
+
+  build:
+    name: Next build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "test": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"Get-ChildItem tests -Filter *.test.mjs | ForEach-Object { node --experimental-strip-types $_.FullName; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } }\"",
+    "test": "node scripts/run-tests.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+// Portable test runner. Replaces the PowerShell one-liner that `npm test` used to be,
+// which could not execute on the ubuntu-latest runners every workflow uses (issue #5).
+//
+// Each tests/*.test.mjs file is a standalone script of node:assert calls, not a
+// node:test suite, so each runs in its own process and its exit code is the verdict.
+// The suite imports .ts modules directly, hence --experimental-strip-types.
+//
+// Node built-ins only, matching scripts/audit-check.mjs and scripts/sql-lint.mjs.
+
+import { readdirSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const testDir = path.join(root, 'tests')
+
+const pattern = process.argv[2]
+const files = readdirSync(testDir)
+  .filter((name) => name.endsWith('.test.mjs'))
+  .filter((name) => !pattern || name.includes(pattern))
+  .sort()
+
+if (files.length === 0) {
+  console.error(pattern ? `No test files match "${pattern}".` : 'No test files found in tests/.')
+  process.exit(1)
+}
+
+const failed = []
+
+for (const name of files) {
+  const started = Date.now()
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', '--disable-warning=ExperimentalWarning', path.join(testDir, name)],
+    { cwd: root, stdio: 'inherit' },
+  )
+
+  const elapsed = Date.now() - started
+  const code = result.status
+
+  if (result.error) {
+    failed.push(`${name} (${result.error.message})`)
+    console.error(`FAIL ${name} — ${result.error.message}`)
+  } else if (result.signal) {
+    failed.push(`${name} (killed by ${result.signal})`)
+    console.error(`FAIL ${name} — killed by ${result.signal}`)
+  } else if (code !== 0) {
+    failed.push(`${name} (exit ${code})`)
+    console.error(`FAIL ${name} — exit ${code}`)
+  } else {
+    console.log(`ok   ${name} (${elapsed} ms)`)
+  }
+}
+
+console.log(`\nPASS=${files.length - failed.length} FAIL=${failed.length}`)
+
+if (failed.length > 0) {
+  console.error(`\nFailing files:\n${failed.map((entry) => `  - ${entry}`).join('\n')}`)
+  process.exit(1)
+}


### PR DESCRIPTION
Closes #5

CI had four jobs and none of them ran the suite or built the app. `npm test` was also a PowerShell one-liner, so it could not have executed on the `ubuntu-latest` runners every workflow uses even if a job had invoked it. Until this lands, no gate in any later issue can be evidenced.

## Changes

| File | Change |
|---|---|
| `scripts/run-tests.mjs` | **New** — portable runner. Each `tests/*.test.mjs` is a standalone `node:assert` script, not a `node:test` suite, so each runs in its own process and its exit code is the verdict. Node built-ins only, matching `scripts/audit-check.mjs` and `scripts/sql-lint.mjs`. |
| `package.json` | `test` is now `node scripts/run-tests.mjs`. No dependency changes. |
| `.github/workflows/ci.yml` | **New** — `test` and `build` jobs on `ubuntu-latest`, Node 22, matching the existing workflows. |
| `.gitattributes` | **New** — pins LF. See below. |

## The `.gitattributes` half, and why it is in this PR

`tests/spot-locations-directory.test.mjs` compares `supabase/migrations/0004_spot_locations_directory.sql` to `renderLocationsMigration()` **byte-for-byte**. With `core.autocrlf=true` and no `.gitattributes`, the checked-out `.sql` is CRLF while the generator emits LF, so that gate fails on Windows for a reason that has nothing to do with the SQL:

```
identical raw       : false
identical normalised: true
disk has CRLF       : true
gen  has CRLF       : false
```

**No SQL changed.** `0004` is byte-identical modulo line endings, and `git add --renormalize .` staged zero content changes — the blobs were already LF in the index. Without this, a Windows contributor cannot get a green suite, which is the same "gate that cannot be evidenced" problem this issue is about.

## Checklist

- [x] Replace the PowerShell test script with a portable runner
- [x] Add a workflow job running the suite on `ubuntu-latest`
- [x] Add `next build` to CI
- [ ] Make both required checks on `main` — applied after merge, once the contexts have reported once

## Two findings

**The build completes.** The issue recorded `npx next build` not finishing inside a 7-minute local timeout, unverified as to cause. It finishes: **exit 0 in 233 s**, 405 static paths. Cold-cache artifact, not a real problem.

**`src/middleware.ts` exists.** `next build` reports `ƒ Middleware 31 kB`. `Docs/DECISIONS.md` D-20 waives eight high-severity `next` advisories on a reachability argument whose first clause is *"This app has no `middleware.ts`"*, and states that introducing one invalidates the waiver. It has been introduced. Out of scope here; flagged rather than silently carried.

## Gate

```
=== npm run lint ===
> next lint
./src/app/how-it-works/page.tsx
113:19  Warning: Using `<img>` could result in slower LCP ...  @next/next/no-img-element
./src/components/RealTimeBoard.tsx
50:6  Warning: React Hook useEffect has missing dependencies: 'fetchSpots' and 'supabase'.
exit=0
```
(both warnings pre-existing, in files this PR does not touch)

```
=== npm run typecheck ===
> tsc --noEmit
exit=0
```

```
=== npm run test ===
ok   spot-directory.test.mjs (293 ms)
spot directory: 50 spots seeded (42 legacy inventory + 8 added), 41 active, 0 lib/ai imports
ok   spot-locations-directory.test.mjs (835 ms)
ok   spot-search.test.mjs (383 ms)
ok   sql-migration-harness.test.mjs (238 ms)
ok   supabase-server-client.test.mjs (157 ms)

PASS=27 FAIL=0
exit=0
```

```
=== npm run build ===
+ First Load JS shared by all                                             87.3 kB
ƒ Middleware                                                              31 kB
=== BUILD EXIT: 0  elapsed: 233.395048 s ===
```

`live-rls.test.mjs` skips itself without `.env.preview.local`, so the suite is green in CI without database credentials and never targets production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)