### PR TITLE
One migration lineage: this repo's 0001-0007, and retire the legacy tables

### DIFF
--- a/Docs/2026-08-20-adr-sluglines-is-the-host-repo.md
+++ b/Docs/2026-08-20-adr-sluglines-is-the-host-repo.md
@@ -1,9 +1,17 @@
 # ADR — `sluglines` is the host repo; `Sluglines-AI`'s schema is the ancestry
 
 - **Date:** 2026-08-20
-- **Status:** Accepted
+- **Status:** Accepted, with the schema-ancestry decision **superseded 2026-08-22** — see `Docs/DECISIONS.md` **D-34**
 - **Supersedes:** §5 of `Docs/2026-08-14-consolidated-architecture.md` (rev. 5.3), which adopted `Sluglines-AI` as the canonical repo
 - **Closes:** §15 Q1 (which repo name survives)
+
+> **Superseded in part.** The three bullets below that pick `Sluglines-AI`'s migrations as the
+> schema ancestry — *"Schema ancestry"*, *"Squash, don't reconcile"*, and *"`codex/phase-3-4` is
+> demoted to a content contribution"* — were reversed on 2026-08-22 by `Docs/DECISIONS.md` D-34.
+> They contradicted D-13, which was never revisited, and the lineage they superseded is the one
+> that has live RLS evidence behind it and production authorisation. **Everything else in this ADR
+> stands**, including the host-repo decision this document exists to record. Left unedited below as
+> the record of what was decided on 2026-08-20.
 
 ## Context
 

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1539,3 +1539,84 @@ grant, and **counts only** in the return type, no member id and no timestamp.
 
 Then, in order: **apply `0004`** to preview (it unblocks the uuid→spot lookup, dashboard check-in,
 and corridor scoping), and **delete the four dead components** listed above.
+
+---
+
+## D-34 — One lineage, and it is this repo's `0001`–`0007`
+
+**Decision:** the competing-`0001` question (issue #4) closes in favour of **`sluglines`'
+`supabase/migrations/0001`–`0007`**. `Sluglines-AI`'s 24 migrations are **not** adopted, squashed,
+or replayed. This is the lineage that `0001`–`0003` proved live on the preview branch (D-28, D-30)
+and the one authorised for production on 2026-08-21.
+
+**This supersedes one bullet of `Docs/2026-08-20-adr-sluglines-is-the-host-repo.md`** — *"Schema
+ancestry: `Sluglines-AI`'s"* — and its two dependent bullets (*"Squash, don't reconcile"*,
+*"`codex/phase-3-4` is demoted to a content contribution"*). Every other part of that ADR stands:
+`sluglines` is the host repo, there is one Supabase project, and there is one lineage. The ADR was
+right about the shape and wrong about which lineage fills it.
+
+**Why the reversal, stated rather than assumed:**
+
+1. **It contradicts D-13, which was never revisited.** D-13 decided (human, 2026-08-14) that the
+   core is *rebuilt* in `sluglines`, not transplanted, and enumerated the consequences as
+   commitments. `0001`–`0006` **are** that rebuild. The ADR's schema-ancestry bullet re-opened the
+   question six days later without executing it, so the repo has been carrying two contradictory
+   decisions and one implementation.
+2. **The implementation is the one with evidence behind it.** `0001`–`0003` are applied to
+   `xqonrogwwytkmqfinszp` with 38 live RLS assertions green (D-28, D-30). `Sluglines-AI`'s 24
+   migrations have never been applied to any Sluglines project — the correction notice in the
+   architecture doc establishes that as verified-and-false, not merely unverified.
+3. **Adopting the other lineage is a different project.** The ADR itself says the absorption is
+   also a Next 14→16 / React 18→19 / Tailwind 3→4 upgrade that "cannot be done incrementally". The
+   app layer it would bring — the AI/chat layer and the ride-coordinator UI — is explicitly out of
+   scope for P2. Nothing in the content cutover depends on it.
+4. **Reversal stays cheap.** The ADR's own argument is that the decision is free while the database
+   is empty and expensive afterwards. It is still empty. Whichever way this goes it must go before
+   the pilot, and only one of the two candidates can be evidenced today.
+
+**What is NOT decided here:** whether `Sluglines-AI` is absorbed *at all*, and on what timetable.
+That question survives this entry intact; it is a repo-topology and upgrade decision, and it no
+longer blocks applying a schema to production. Issue #3 (the per-tool kill switches) remains tied to
+it.
+
+### The three legacy tables, and why `0007` must land before `0001` reaches production
+
+Read from `bwpguotjzczmieeepczf` on 2026-08-22, not inferred:
+
+| Object | State |
+|---|---|
+| `spot_status`, `profiles`, `commute_log` | 3 tables, **0 rows each** |
+| `spot_status` UPDATE policy `Anyone can update spot counts` | `to public`, `using (true) with check (true)` |
+| `commute_log` INSERT `Auth insert commute log` | `to public`, `with check (true)` |
+| `commute_log` SELECT `Public read commute log` | `to public`, `using (true)` |
+| `profiles` SELECT/UPDATE | `to public`, scoped `auth.uid() = id` |
+| Trigger `on_auth_user_created` on `auth.users` | live, runs `public.handle_new_user()` |
+| `public.handle_new_user()` | body is `insert into public.profiles (id, email) values (new.id, new.email)` |
+| `public.reset_daily_counts()` | zeroes `spot_status` counters |
+
+Two consequences, and the second is the load-bearing one:
+
+1. **Three unauthenticated write/read paths are live in production today.** rev. 5.3 §14 risk 4 and
+   the live half of D-24, still open because D-24 correctly declined to drop them before a
+   replacement existed. The replacement exists now.
+2. **`0001` does not remove the legacy auth trigger; it adds a second one.**
+   `on_auth_user_created_member` and `on_auth_user_created` would both be armed on `auth.users`
+   insert. The moment identity works (#24), **every signup writes the member's email address into
+   `profiles.email`** — `text unique not null` — which is precisely the duplication of an identity
+   attribute into an application table that rev. 5.3 §6 forbids and that `0001`'s own comment on
+   `handle_new_member()` singles out. This is not cleanup that can follow the apply; it is a
+   precondition of it.
+
+`0007_retire_legacy_tables.sql` drops the trigger, both functions, and the three tables, and asserts
+its own post-condition so a partial apply cannot report success. It creates nothing, so R3–R11 have
+no subject; `sql:check` reports 7 migrations, 173 statements, 0 violations.
+
+`riders`, `drivers` and `alerts` are deliberately **not** in `0007`: they exist only in the
+quarantined `supabase/schema.sql` and were never applied to production, which holds three tables and
+not six. That file stays quarantined and `tests/legacy-schema-risks.test.mjs` keeps pinning its
+unsafe set.
+
+**Consequence for #19:** the production apply is `0001`–**`0007`**, not `0001`–`0006`. Applying the
+authorised six without the seventh would arm the email-copying trigger described above.
+
+**Status:** DECIDED. `0007` written, `APPLIED: no`. Nothing applied to any database by this entry.

--- a/supabase/migrations/0007_retire_legacy_tables.sql
+++ b/supabase/migrations/0007_retire_legacy_tables.sql
@@ -1,0 +1,102 @@
+-- =============================================================================
+-- 0007_retire_legacy_tables.sql
+--
+-- APPLIED: no
+--
+-- Retires the three legacy tables that are the entire contents of the production
+-- database today, together with the two functions and the one auth trigger that
+-- feed them. Closes the third item of issue #4 and the live half of
+-- Docs/DECISIONS.md D-24.
+--
+-- WHY THIS IS A PREREQUISITE FOR 0001, NOT A TIDY-UP AFTER IT
+-- -----------------------------------------------------------------------------
+-- Production carries an `on_auth_user_created` trigger on `auth.users` running
+-- the legacy `handle_new_user()`, whose whole body is:
+--
+--     insert into public.profiles (id, email) values (new.id, new.email);
+--
+-- `profiles.email` is `text unique not null`. So the first time identity works,
+-- every signup copies the member's email address out of Supabase Auth into an
+-- application table -- the exact pattern rev. 5.3 sec.6 forbids and that
+-- 0001_rebuild_foundation.sql's own comment on `handle_new_member()` calls out by
+-- name. 0001 installs a second, separate trigger (`on_auth_user_created_member`);
+-- it does not remove this one. Applying 0001 to production without this file
+-- leaves both triggers armed on the same event.
+--
+-- WHAT IS LIVE IN PRODUCTION RIGHT NOW, read from pg_policies on 2026-08-22
+-- -----------------------------------------------------------------------------
+--   spot_status   UPDATE  to public   using (true) with check (true)
+--   commute_log   INSERT  to public   with check (true)
+--   commute_log   SELECT  to public   using (true)
+--   profiles      SELECT/UPDATE to public, scoped to auth.uid() = id
+--
+-- The first three are unauthenticated write and read paths over the whole table
+-- -- rev. 5.3 sec.14 risk 4, and the reason D-24 recorded the risk as live rather
+-- than mitigated. All three tables hold zero rows, so dropping them destroys no
+-- data; it removes the policies by removing what they are attached to.
+--
+-- The `riders`, `drivers` and `alerts` tables from supabase/schema.sql are NOT
+-- dropped here, because they were never applied to production -- the database
+-- holds three tables, not six. `supabase/schema.sql` stays quarantined and
+-- unapplied; tests/legacy-schema-risks.test.mjs continues to pin its unsafe set.
+--
+-- Nothing in this file creates a table, a policy, a function or a grant, so
+-- R3-R11 have no subject. That is the point: it only removes.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- The auth trigger first. Dropping it before its function means the function is
+-- never momentarily referenced by a trigger that no longer has a body.
+-- -----------------------------------------------------------------------------
+drop trigger if exists on_auth_user_created on auth.users;
+
+drop function if exists public.handle_new_user();
+
+-- Zeroed spot_status counters on a schedule. Its only table is dropped below.
+drop function if exists public.reset_daily_counts();
+
+
+-- -----------------------------------------------------------------------------
+-- The tables. commute_log references profiles(id), so it goes first and no
+-- cascade is needed -- an unexpected dependency should fail this migration
+-- loudly rather than be silently dropped along with it.
+-- -----------------------------------------------------------------------------
+drop table if exists public.commute_log;
+drop table if exists public.profiles;
+drop table if exists public.spot_status;
+
+
+-- -----------------------------------------------------------------------------
+-- Post-condition, asserted in the migration itself so a partial apply cannot
+-- report success. The same shape 0004's seed block uses.
+-- -----------------------------------------------------------------------------
+do $check$
+declare
+  v_remaining text;
+begin
+  select string_agg(c.relname, ', ' order by c.relname)
+    into v_remaining
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'public'
+    and c.relkind = 'r'
+    and c.relname in ('spot_status', 'profiles', 'commute_log');
+
+  if v_remaining is not null then
+    raise exception 'legacy tables still present after 0007: %', v_remaining;
+  end if;
+
+  if exists (
+    select 1 from pg_trigger t
+    join pg_class c on c.oid = t.tgrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'auth' and c.relname = 'users'
+      and t.tgname = 'on_auth_user_created' and not t.tgisinternal
+  ) then
+    raise exception 'legacy auth trigger on_auth_user_created still present after 0007';
+  end if;
+
+  raise notice 'legacy retirement: 3 tables, 2 functions and 1 auth trigger removed';
+end
+$check$;


### PR DESCRIPTION
Closes #4

Two `0001` lineages existed and neither was applied to the live database.

## The decision

The question closes in favour of **this repo's `supabase/migrations/0001`–`0007`**. `Sluglines-AI`'s 24 migrations are **not** adopted, squashed, or replayed.

That reverses one bullet of `Docs/2026-08-20-adr-sluglines-is-the-host-repo.md` — *"Schema ancestry: `Sluglines-AI`'s"* — and its two dependents. **This is a deliberate, visible reversal, not an oversight**, and it is recorded as D-34 with the ADR annotated to point at it. Reasons:

1. **It contradicts D-13, which was never revisited.** D-13 decided (human, 2026-08-14) that the core is *rebuilt* here rather than transplanted. `0001`–`0006` **are** that rebuild. The ADR re-opened the question six days later without executing it, so the repo has been carrying two contradictory decisions and one implementation.
2. **Only one candidate has evidence.** `0001`–`0003` are applied to `xqonrogwwytkmqfinszp` with 38 live RLS assertions green (D-28, D-30). `Sluglines-AI`'s 24 migrations have never been applied to any Sluglines project — the architecture doc's own correction notice establishes that as verified-and-false.
3. **The other lineage is a different project.** The ADR says its absorption is also a Next 14→16 / React 18→19 / Tailwind 3→4 upgrade that "cannot be done incrementally", and the app layer it brings — AI/chat, ride-coordinator UI — is out of scope for P2.

**Not decided here:** whether `Sluglines-AI` is absorbed at all. That survives intact; it just no longer blocks applying a schema.

## `0007_retire_legacy_tables.sql`, and why it is a prerequisite for #19

Checklist item 3 ("Drop `spot_status`, `profiles`, `commute_log`"). While writing it I read production rather than assuming, and found the reason it cannot wait until after the apply:

```
Trigger on_auth_user_created on auth.users  ->  public.handle_new_user()
  insert into public.profiles (id, email) values (new.id, new.email);
```

`profiles.email` is `text unique not null`. `0001` installs a **second** trigger on the same event (`on_auth_user_created_member`) — it does not remove this one. Apply `0001` to production without `0007` and both are armed, so the first successful signup (#24) copies the member's email address into an application table. That is the exact pattern rev. 5.3 §6 forbids, and `0001`'s own comment on `handle_new_member()` names it.

It also removes three unauthenticated paths that are live in production **right now** (read from `pg_policies`, 2026-08-22):

| Table | Command | Roles | Predicate |
|---|---|---|---|
| `spot_status` | UPDATE | `public` | `using (true) with check (true)` |
| `commute_log` | INSERT | `public` | `with check (true)` |
| `commute_log` | SELECT | `public` | `using (true)` |

rev. 5.3 §14 risk 4 and the live half of D-24. **All three tables hold zero rows**, so nothing is destroyed — the policies go because what they attach to goes.

`riders`/`drivers`/`alerts` are deliberately **not** dropped: they exist only in the quarantined `supabase/schema.sql` and never reached production, which holds three tables and not six.

The migration asserts its own post-condition (tables gone, trigger gone) so a partial apply cannot report success.

## Consequence for #19

**The production apply is `0001`–`0007`, not `0001`–`0006`.** Applying the authorised six without the seventh arms the email-copying trigger above. Flagged here rather than discovered there.

## Nothing was applied

`APPLIED: no`. No database was written by this change. The two reads against production were `pg_policies` and `pg_proc`/`pg_trigger` catalogue queries.

## Checklist

- [x] One lineage, recorded — D-34
- [x] Drop `spot_status`, `profiles`, `commute_log` — `0007`, written
- [x] Port the directory/content additions — already present as `0004`; no port needed once this lineage wins
- [ ] ~~Squash `Sluglines-AI`'s `0001`–`0024`~~ — reversed, see above
- [ ] Apply to `phase-3-4-staging` — deferred to #19, which owns the `APPLIED:` header changes (`0004` is a generated file whose header is inside the byte-for-byte guard, so moving it off `no` is one coherent change, not two)

## Gate

```
=== npm run sql:check ===
sql-lint: 7 migration(s), 173 statement(s), 0 violations.
sql-lint: static shape check only -- this does not verify RLS behaviour.
seed-locations: supabase/migrations/0004_spot_locations_directory.sql is up to date (50 spots)
exit=0
```

```
=== npm run lint ===       LINT=0   (2 pre-existing warnings, untouched files)
=== npm run typecheck ===  TYPECHECK=0
=== npm run test ===       PASS=27 FAIL=0   TEST=0
=== npm run build ===      BUILD=0  elapsed=242s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)