### PR TITLE
Recount baseline N to 28/872 and make it machine-checked

### DIFF
--- a/Docs/2026-08-14-consolidated-architecture.md
+++ b/Docs/2026-08-14-consolidated-architecture.md
@@ -1,7 +1,7 @@
 # Sluglines — Consolidated Architecture & Product Plan
 
 - **Status:** IMPLEMENTED (Phase 0/1 complete, 2026-08-14); §5 SUPERSEDED and §3.4 CORRECTED 2026-08-20 — see the rev. 6 banner below
-- **Baseline N:** 26 test files, all passing (verified 2026-08-20). The former record of "12 files / 99 assertions (D-25)" was stale by more than 2×; the assertion count has not yet been recomputed. See issue #7.
+- **Baseline N:** 28 test files / 872 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
 - **Repo State:** Branch `codex/phase-3-4` at commit `8e1ed0d`, pushed to `origin`. `main` = `origin/main` = `97ca88f`.
 
 - **Phase 0/1 implementation summary:**

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1620,3 +1620,50 @@ unsafe set.
 authorised six without the seventh would arm the email-copying trigger described above.
 
 **Status:** DECIDED. `0007` written, `APPLIED: no`. Nothing applied to any database by this entry.
+
+---
+
+## D-35 — Baseline `N` recounted to 28 files / 872 assertion call sites, and made machine-checked
+
+**Supersedes D-25** (12 files / 99 assertions), which in turn corrected D-4 (12 / 137). This entry
+is written rather than editing either, per the append-only rule D-25 itself followed.
+
+**The recount, taken 2026-08-22 with D-25's instrument** — source-level `assert(` / `assert.method(`
+call sites, counting what is *written* rather than what executes, which is the distinction that made
+D-4's 137 unreproducible:
+
+| | Files | Assertion call sites |
+|---|---|---|
+| D-4 (2026-08-14) | 12 | 137 — included a working-tree file that never landed |
+| D-25 (2026-08-14) | 12 | 99 |
+| Architecture header (2026-08-20) | 26 | not recomputed |
+| **This entry (2026-08-22)** | **28** | **872** |
+
+The 28th file is `tests/baseline-n.test.mjs`, added by this change; the 27th is the count the repo
+already carried when issue #7 measured 26 — one further test file landed between that review and
+this recount.
+
+**Why the number keeps drifting, and what actually stops it.** Three sessions have now recorded a
+different `N`, and each correction was itself prose in a document nothing checks. §11's gates are
+written as *"no gate may reduce `N`"*, so a stale baseline is not a bookkeeping annoyance: it means
+every gate compares against the wrong number **in the permissive direction**. At `N = 12`, a change
+could have deleted sixteen test files and still cleared the gate.
+
+So the number stops living only in prose. The architecture document's header is the single source of
+truth, and `tests/baseline-n.test.mjs` re-measures the repo and fails when the two disagree. Adding
+or removing a test file, or adding assertions, now fails the suite until the header is updated in
+the same change. That is the third work item of issue #7, and it is the only one of the three that
+prevents a fourth recount.
+
+The same file carries a floor (`>= 28` files, `>= 872` sites) so that lowering the repo and the
+header together in one edit is still a deliberate act rather than a silent one, and two structural
+assertions that were previously nobody's job: every test file matches `^[a-z0-9-]+\.test\.mjs$`, and
+`tests/` is flat. `scripts/run-tests.mjs` globs exactly that pattern and does not recurse, so a file
+named `.test.js` or placed in a subdirectory would count nowhere and run nowhere — which is a way to
+lose coverage that no count would catch.
+
+**Not claimed:** that 872 is a measure of coverage. It counts call sites in source. Two files with
+identical assertions over the same code path count twice, and a loop asserting fifty times counts
+once. It is a drift detector, which is what `N` is used for.
+
+**Status:** RECORDED and ENFORCED.

--- a/tests/baseline-n.test.mjs
+++ b/tests/baseline-n.test.mjs
@@ -1,0 +1,88 @@
+// The rev. 5.3 §11 baseline `N`, machine-checked.
+//
+// `N` is not decorative: the phase gates are written as "no gate may reduce N",
+// so a stale `N` makes every one of them compare against the wrong number in the
+// permissive direction. It has now drifted twice — D-4 recorded 137 assertions
+// for a working-tree file that never landed, D-25 corrected it to 99, and by
+// 2026-08-20 the file count alone was off by more than 2x (issue #7).
+//
+// So the number stops living only in prose. The architecture document's header
+// is the single source of truth, this file re-measures the repo, and the two
+// must agree. Adding or deleting a test file, or adding assertions, fails here
+// until the header is updated in the same change — which is the point.
+
+import { strict as assert } from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const testDir = path.join(root, 'tests')
+const ARCHITECTURE_DOC = 'Docs/2026-08-14-consolidated-architecture.md'
+
+// The instrument, stated so a later recount uses the same one D-25 used:
+// source-level `assert(` / `assert.method(` call sites. It counts what is
+// written, not what executes — a call inside a loop is one site, which is
+// exactly why D-4's 137 could not be reproduced.
+const ASSERT_CALL = /\bassert(?:\.[A-Za-z]+)?\s*\(/g
+
+const files = fs
+  .readdirSync(testDir)
+  .filter((name) => name.endsWith('.test.mjs'))
+  .sort()
+
+const measured = files.reduce(
+  (acc, name) => {
+    const source = fs.readFileSync(path.join(testDir, name), 'utf8')
+    return { files: acc.files + 1, assertions: acc.assertions + (source.match(ASSERT_CALL) ?? []).length }
+  },
+  { files: 0, assertions: 0 }
+)
+
+// -----------------------------------------------------------------------------
+// The header is the record; this file is the enforcement
+// -----------------------------------------------------------------------------
+const doc = fs.readFileSync(path.join(root, ARCHITECTURE_DOC), 'utf8')
+const header = /\*\*Baseline N:\*\*\s*(\d+)\s+test files\s*\/\s*([\d,]+)\s+assertion call sites/.exec(doc)
+
+assert.ok(
+  header,
+  `${ARCHITECTURE_DOC} must carry a header line of the form ` +
+    '"**Baseline N:** <n> test files / <n> assertion call sites"'
+)
+
+const recorded = { files: Number(header[1]), assertions: Number(header[2].replace(/,/g, '')) }
+
+assert.equal(
+  measured.files,
+  recorded.files,
+  `${ARCHITECTURE_DOC} records ${recorded.files} test files; the repo has ${measured.files}. ` +
+    'Update the header in the change that moved it, and add a DECISIONS entry if N went down.'
+)
+
+assert.equal(
+  measured.assertions,
+  recorded.assertions,
+  `${ARCHITECTURE_DOC} records ${recorded.assertions} assertion call sites; the repo has ` +
+    `${measured.assertions}. Update the header in the change that moved it.`
+)
+
+// A floor as well as an equality, so a change that lowers both the repo and the
+// header in one edit still has to be deliberate about it.
+assert.ok(measured.files >= 28, `N must not fall below the 2026-08-22 baseline of 28 files`)
+assert.ok(measured.assertions >= 872, `N must not fall below the 2026-08-22 baseline of 872 assertion call sites`)
+
+// Every test file is reachable by the runner: scripts/run-tests.mjs globs exactly
+// this pattern, so a file named .test.js or tests/foo/bar.test.mjs would count
+// nowhere and run nowhere.
+for (const name of files) {
+  assert.match(name, /^[a-z0-9-]+\.test\.mjs$/, `${name}: test files are kebab-case *.test.mjs at the top of tests/`)
+}
+
+const nested = fs.readdirSync(testDir, { withFileTypes: true }).filter((entry) => entry.isDirectory())
+assert.deepEqual(
+  nested.map((entry) => entry.name),
+  [],
+  'tests/ is flat: scripts/run-tests.mjs does not recurse, so a nested file would never run'
+)
+
+console.log(`baseline N: ${measured.files} test files / ${measured.assertions} assertion call sites`)


### PR DESCRIPTION
Closes #7

## The recount

D-25's instrument — source-level `assert(` / `assert.method(` call sites, counting what is *written* rather than what executes, which is the distinction that made D-4's 137 unreproducible:

| | Files | Assertion call sites |
|---|---|---|
| D-4 (2026-08-14) | 12 | 137 — included a working-tree file that never landed |
| D-25 (2026-08-14) | 12 | 99 |
| Architecture header (2026-08-20) | 26 | not recomputed |
| **This PR (2026-08-22)** | **28** | **872** |

The 28th file is the checker added here; the 27th landed between issue #7's review and this recount.

## Why the third work item is the only one that matters

`N` has now drifted three times, and each correction was prose in a document nothing checks — which is why there was a next one. §11's gates read *"no gate may reduce `N`"*, so a stale baseline makes every gate compare against the wrong number **in the permissive direction**. At `N = 12`, a change could have deleted sixteen test files and still cleared the gate.

So the number stops living only in prose:

- The architecture header is the **single source of truth** and states both numbers.
- `tests/baseline-n.test.mjs` re-measures the repo and fails when header and repo disagree. Adding or deleting a test file, or adding assertions, fails the suite until the header moves in the same change.
- A **floor** as well as an equality (`>= 28` files, `>= 872` sites), so lowering the repo and the header together in one edit is still deliberate rather than silent.

## Two structural assertions that were nobody's job

`scripts/run-tests.mjs` globs `tests/*.test.mjs` and does not recurse. So the test also asserts every file matches `^[a-z0-9-]+\.test\.mjs$` and that `tests/` is flat — a file named `.test.js`, or one placed in a subdirectory, would count nowhere and run nowhere. That is a way to lose coverage no count would catch.

## Not claimed

872 is not a coverage measure. Two files asserting identically over the same path count twice; a loop asserting fifty times counts once. It is a drift detector, which is what `N` is used for.

## Gate

```
=== npm run lint ===       LINT=0        (2 pre-existing warnings, untouched files)
=== npm run typecheck ===  TYPECHECK=0
=== npm run test ===       PASS=28 FAIL=0   TEST=0
                           baseline N: 28 test files / 872 assertion call sites
=== npm run build ===      BUILD=0  elapsed=237s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)