### PR TITLE
Spot photographs: build the field and the no-image state, migrate nothing, say why

### DIFF
--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1882,3 +1882,95 @@ snapshot over — a tag keeps `e7b0f49` reachable permanently while removing it 
 Every claim above is checkable against it.
 
 **Status:** DONE. Four issues open; one document adopted; branch archived.
+
+---
+
+## D-39 — There are no per-location photographs to migrate. All 50 spots get the reserved no-photograph state
+
+**Decision:** issue #18's infrastructure ships — an optional `image` field on `SpotLocation`, a
+reserved 4:3 media area, `next/image` with explicit dimensions, and a test that refuses any image
+not sourced from `sluglines.com/images/slugging_locations/` — and **zero images are migrated**,
+because the legacy site has none of the kind the issue is about.
+
+### What was actually found
+
+All 27 distinct assets under `sluglines.com/images/slugging_locations/` were pulled and **visually
+inspected** on 2026-08-22, not classified from filenames. All 42 legacy spot pages were reachable
+and **no URL was dead**. The full classification is the appendix to `Docs/asset-register.md`.
+
+| Kind | Count |
+|---|---|
+| Google satellite / aerial tile (several with a visible `Google` credit and `Map data ©2016 Google`) | 12 |
+| Third-party transit or parking schematic (VDOT, VRE, WMATA, Fairfax County) | 8 |
+| Annotated aerial route diagram, 2018–2019 change notices | 6 |
+| Promotional flyer carrying a Facebook URL, a Twitter handle and an email address | 1 |
+| **Photograph of a location** | **0** |
+
+`Horner_Road.jpg` is a Google satellite tile with slug-line labels drawn on it and a `sluglines.com`
+watermark. `Route17.jpg` is an unannotated satellite tile. `Bobs.jpg` is a bus-bay and parking
+schematic. `Crystal_City_12th_St.jpg` and `Crystal_City_23rd_St.jpg` are the same WMATA station map.
+
+### Why none of it ships
+
+The instruction for this milestone is explicit that the spots without a photograph get a designed
+no-image state — *"not a broken img, not stretched filler, **not a satellite tile posing as a
+photograph**"*. The finding is that **every** candidate is one of those. Applying the rule to what
+was actually there yields "migrate none"; migrating them anyway would be the exact failure the rule
+names, applied to 25 spots instead of avoided on 18.
+
+Three independent lines converge on the same answer, which is why this is not a close call:
+
+1. **The satellite tiles are Google Maps imagery.** `Docs/asset-register.md` already says *"embedded
+   map imagery has separate terms"*, and several files carry Google's credit inside the pixels.
+2. **The route diagrams are already classified `Historical only`** by that register — *"Staffordboro
+   and Pentagon route diagrams from 2018-2019 … operational directions may have changed"*. Two are
+   dated 2018 in their own filenames. Publishing a 2018 traffic-change notice as a spot's current
+   image tells a commuter something operational that may be years wrong.
+3. **The transit schematics are third-party operator material**, which `Docs/content-sources.md`
+   says to link to rather than copy.
+
+This is the same discipline as D-31 (a `null` coordinate is never guessed, because a plausible guess
+is indistinguishable from a surveyed one) and D-33 (`unavailable`, never a fabricated zero). An
+aerial view of a car park in the slot labelled "photograph of this spot" is a fabricated answer to
+the question the slot asks.
+
+### The audit was wrong, in a specific and instructive way
+
+Issue #18 records *"32 legacy spots with a photo, 10 without"*. The real figure is **25 with an
+asset under `slugging_locations/`, 17 without** — and the seven-spot gap is made up entirely of the
+assets the issue's own guidance excludes:
+
+| Excluded | Spots | Why |
+|---|---|---|
+| Image at `sluglines.com/images/` rather than `…/slugging_locations/` | `franconia-springfield`, `landmark-mall`, `van-dorn-st` | Outside the one permitted path |
+| Only image is an `lh5.googleusercontent.com` avatar | `mark-center`, `navy-yard`, `rosslyn` | A commenter's face — the trap the issue names |
+| Only image is `direction.png` | `telegraph-rd` | A UI icon, used on 8 pages |
+
+25 + 3 + 3 + 1 = 32. The audit counted the avatars it warned about.
+
+One further correction: the live site now references an asset the 2026-07-11 snapshot missed —
+`sydenstricker-rd` also loads `Saratoga.jpg`, the same schematic the `saratoga` page uses. Not a new
+photograph.
+
+### What ships instead
+
+The reserved 4:3 media area from `Docs/asset-register.md` — *"reserve a stable 4:3 media area, but
+show a neutral route graphic until a current approved photograph exists"* — rendered by
+`src/components/SpotPhoto.tsx`. The box is reserved in **both** branches, so adding a photograph
+later reflows nothing, and the empty branch is a drawn graphic and a sentence that says what it is
+rather than implying a missing file.
+
+`image` stays out of `SEED_COLUMNS`, so `0004_spot_locations_directory.sql` is byte-identical and
+`sql:check` still reports 7 migrations / 173 statements / 0 violations. `locations` has no image
+column and `LOCATION_COLUMNS` does not ask for one; both mappings in `public-location.ts` resolve
+the field from the committed directory, so the table and the file still produce the same record.
+
+**Consequence for #26:** its scope changes from *"source photographs for the 18 spots that have
+none"* to **all 50**. Recorded as a comment on that issue.
+
+**Filed, not built:** the diagrams and schematics are genuinely useful to a commuter — a lot layout
+showing where the line forms is worth more than a photograph of tarmac. Publishing them **labelled
+as maps**, with the third-party rights question answered, is issue #39. It is a different surface
+from the one #18 asks for and is not smuggled into it.
+
+**Status:** DONE. Field, media area, guard and audit shipped. Zero images migrated, with reasons.

--- a/Docs/asset-register.md
+++ b/Docs/asset-register.md
@@ -35,3 +35,33 @@ The legacy archive at `C:\Users\kalai\OneDrive\Sluglines` is read-only research 
 - Images: use `next/image`, explicit dimensions, responsive `sizes`, descriptive alt text, and no decorative text baked into the bitmap.
 - Photography intake: record creator, capture date, location, consent status, rights, privacy remediation, and verification date.
 - Never ship an image directly from the OneDrive archive path.
+
+## Appendix — `sluglines.com/images/slugging_locations/`, classified 2026-08-22
+
+Every asset under that path was pulled and **visually inspected** for issue #18. 27 distinct files, referenced by 25 of the 42 legacy spot pages. All 42 pages were reachable and **no URL was dead**.
+
+**None of the 27 is a photograph of a location.**
+
+| Kind | Count | What it actually is |
+|---|---|---|
+| Satellite / aerial tile | 12 | Google Maps imagery, several carrying a visible `Google` credit, `Map data ©2016 Google`, and a `www.sluglines.com` watermark. `Route17.jpg` and `Mine_Road.jpg` are unannotated tiles. |
+| Third-party transit or parking schematic | 8 | VDOT, VRE, WMATA and Fairfax County lot diagrams — bus-bay listings, space counts, ADA and bicycle-parking legends. `Crystal_City_12th_St.jpg` and `Crystal_City_23rd_St.jpg` are the **same** WMATA station map. |
+| Annotated aerial route diagram | 6 | 2018–2019 change notices: *"Changes to Slug pickup location at the Pentagon going to Stafford"*, *"New traffic pattern at the pentagon starting feb 26 2018"*, *"Directions from Frontier Garage to I-95 Express Lanes"*. |
+| Promotional flyer | 1 | `21st-Street.jpg` — a marketing graphic with a speech bubble, the Sluglines logo, a Facebook group URL, a Twitter handle and `admin@SlugLines.com`. |
+| **Photograph of a spot** | **0** | — |
+
+### Consequences under the rules above
+
+- **The satellite tiles fail the "not a satellite tile posing as a photograph" line outright**, and they embed Google Maps imagery, which this register already flags: *"embedded map imagery has separate terms."*
+- **The route diagrams are the entry this register already classifies as `Historical only`** — *"Staffordboro and Pentagon route diagrams from 2018-2019 … operational directions may have changed."* Two of them are dated 2018 in their own filenames.
+- **The transit schematics are third-party operator material**, usable by link rather than by copy, per `Docs/content-sources.md`'s hierarchy (*"link to the operator rather than copying"*).
+- **The flyer carries contact details** and is a publication artefact, not a location record.
+
+So **no asset was migrated**, and all 50 spots render the reserved no-photograph state. See `Docs/DECISIONS.md` **D-39**.
+
+### Two audit corrections
+
+1. Issue #18 recorded *"32 legacy spots with a photo, 10 without"*. The real figure is **25 with an asset, 17 without**. The gap is exactly the assets the issue's own guidance excludes: 3 spots whose only image sits at `sluglines.com/images/` rather than `…/slugging_locations/` (`Franconia-Springfield.jpg`, `Landmark-Mall.jpg`, `Van-Dorn-St.jpg`), 3 whose only image is an `lh5.googleusercontent.com` commenter avatar (`mark-center`, `navy-yard`, `rosslyn`), and 1 whose only image is the `direction.png` UI icon (`telegraph-rd`). 25 + 3 + 3 + 1 = 32.
+2. The live site now references one asset the 2026-07-11 snapshot missed: `sydenstricker-rd` also loads `Saratoga.jpg`, the same file the `saratoga` page uses. Not a new photograph — the same schematic on two pages.
+
+**10 legacy pages carry an `lh5.googleusercontent.com` avatar**: `bobs-old-keene-mill-rd`, `landmark-mall`, `mark-center`, `navy-yard`, `rosslyn`, `route-234`, `route-3-gordon-rd`, `route-610-mine-rd`, `state-department`, `the-pentagon`. These are commenters' faces. They are never migrated, and the test in `tests/spot-photos.test.mjs` refuses any image whose source is not under `slugging_locations/`.

--- a/Docs/consolidated-architecture.md
+++ b/Docs/consolidated-architecture.md
@@ -1,7 +1,7 @@
 # Sluglines — Consolidated Architecture & Product Plan
 
 - **Status:** rev. 6 — IMPLEMENTED (Phase 0/1 complete, 2026-08-14). §3.4, §5 and §15 Q1 are corrected **in place**; this document no longer carries a banner warning that its own body is wrong.
-- **Baseline N:** 28 test files / 874 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
+- **Baseline N:** 29 test files / 904 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
 - **Repo State (2026-08-22):** `main` is the only live branch and carries everything below — `codex/phase-3-4` was merged as PR #1 (`e2d922a`) and deleted. `codex/phase-1` survives as the unreviewed snapshot `e7b0f49` (issue #11). Migrations `0001`–`0007` are in `supabase/migrations/`; `0001`–`0003` are applied to the preview branch `phase-3-4-staging`, and **nothing is applied to production** (issue #19).
 
 - **Phase 0/1 implementation summary:**

--- a/src/components/SpotDetailLayout.tsx
+++ b/src/components/SpotDetailLayout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { ArrowLeft, MapPinned, Navigation, Users } from 'lucide-react'
 import CommunityLinksCard from '@/components/CommunityLinksCard'
 import SpotLiveCounts from '@/components/SpotLiveCounts'
+import SpotPhoto from '@/components/SpotPhoto'
 import SpotQuickFacts from '@/components/SpotQuickFacts'
 import { getPrimaryFacebookUrlForSpot } from '@/lib/community-channels'
 import type { PublicCountsAvailability, PublicSpotCounts } from '@/lib/domain/public-counts'
@@ -128,6 +129,7 @@ export default function SpotDetailLayout({ location, counts, availability }: Spo
           </main>
 
           <aside className="space-y-4">
+            <SpotPhoto image={location.image} spotName={location.name} />
             <SpotLiveCounts
               spotName={location.name}
               counts={counts}

--- a/src/components/SpotPhoto.tsx
+++ b/src/components/SpotPhoto.tsx
@@ -1,0 +1,69 @@
+import Image from 'next/image'
+import { Route } from 'lucide-react'
+import type { SpotImage } from '@/lib/domain/locations'
+
+interface SpotPhotoProps {
+  image?: SpotImage
+  spotName: string
+}
+
+/**
+ * The spot's media area — `Docs/asset-register.md`: *"reserve a stable 4:3 media
+ * area, but show a neutral route graphic until a current approved photograph
+ * exists."*
+ *
+ * The 4:3 box is reserved in **both** states, which is the whole design. A page
+ * that grows a photo slot only when a photo exists reflows the moment one is
+ * added, and reads as broken when one is missing; a page that reserves the box
+ * and says what is in it reads as complete either way.
+ *
+ * No spot has a photograph today (issue #18, `Docs/DECISIONS.md` D-39), so what
+ * every spot renders is the second branch. It is deliberately a drawn graphic
+ * and a sentence, not an `<img>` with a missing file, not a stretched placeholder
+ * photo, and not a satellite tile standing in for a photograph nobody took —
+ * the same discipline as `null` coordinates never being guessed (D-31) and counts
+ * rendering `unavailable` rather than a fabricated zero (D-33).
+ */
+export default function SpotPhoto({ image, spotName }: SpotPhotoProps) {
+  if (image) {
+    return (
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-100">
+        <Image
+          src={image.src}
+          alt={image.alt}
+          width={image.width}
+          height={image.height}
+          sizes="(min-width: 1024px) 360px, 100vw"
+          className="h-full w-full object-cover"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex aspect-[4/3] w-full flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-100 px-6 text-center">
+      <RouteGraphic />
+      <p className="text-sm font-semibold text-slate-700">No photograph of this spot yet</p>
+      <p className="max-w-xs text-xs leading-relaxed text-slate-600">
+        We would rather show nothing than a stock image or a satellite view of the car park. Use{' '}
+        <span className="font-semibold">Open in Maps</span> to see {spotName} from above.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * A route line, drawn. Original and code-native, per the asset register's Phase 1
+ * visual requirement — it costs no image rights, needs no network request, and
+ * cannot be mistaken for a photograph of anywhere.
+ */
+function RouteGraphic() {
+  return (
+    <span
+      aria-hidden
+      className="flex h-12 w-12 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-500"
+    >
+      <Route className="h-6 w-6" />
+    </span>
+  )
+}

--- a/src/lib/domain/locations.ts
+++ b/src/lib/domain/locations.ts
@@ -42,6 +42,40 @@
 export type SpotCorridor = 'I-395 / I-95' | 'I-66'
 export type SpotDirection = 'Morning' | 'Afternoon'
 
+/**
+ * A photograph of a spot, self-hosted.
+ *
+ * NOT a database column, deliberately. `0004_spot_locations_directory.sql` is
+ * generated from this file by `scripts/seed-locations.mjs` and guarded
+ * byte-for-byte, so a field that entered `SEED_COLUMNS` would regenerate it.
+ * Nothing queries by image and no RLS decision attaches to a static asset path,
+ * so this lives in the domain module and `0004` applies untouched (issue #18).
+ *
+ * `src` is always a path under `public/`. Never a remote URL: a hotlink to
+ * sluglines.com dies the day WordPress is cancelled, which is the point of the
+ * migration.
+ *
+ * **No spot carries one today, and that is a finding rather than an omission.**
+ * All 27 assets under `sluglines.com/images/slugging_locations/` were pulled and
+ * inspected on 2026-08-22: every one is a satellite tile, a third-party transit
+ * or parking schematic, an annotated aerial route diagram, or a promotional
+ * flyer. Zero are photographs of a location. The classification is in
+ * `Docs/asset-register.md`; the reasoning is `Docs/DECISIONS.md` D-39.
+ */
+export interface SpotImage {
+  /** Path under `public/`, e.g. `/spots/horner-rd.jpg`. Never a remote URL. */
+  src: string
+  /** Intrinsic pixel size, so `next/image` reserves the box and CLS stays at 0. */
+  width: number
+  height: number
+  /** Describes the spot for a screen reader, not the file. */
+  alt: string
+  /** Provenance. Asserted to be under sluglines.com/images/slugging_locations/. */
+  sourceUrl: string
+  /** ISO date the file was pulled from the legacy site. */
+  fetchedAt: string
+}
+
 export interface SpotLocation {
   /** Canonical lower-case key: the database key and the legacy URL slug. */
   slug: string
@@ -64,6 +98,15 @@ export interface SpotLocation {
   linesTo?: string[]
   fbUrl?: string
   notes?: string
+  /** Absent where no approved photograph exists. Never a stand-in. */
+  image?: SpotImage
+}
+
+/** The only host a migrated image may have come from (issue #18). */
+export const LEGACY_IMAGE_PREFIX = 'https://sluglines.com/images/slugging_locations/'
+
+export function spotImage(slug: string): SpotImage | undefined {
+  return findSpotLocation(slug)?.image
 }
 
 export const SPOT_CORRIDORS: readonly SpotCorridor[] = ['I-395 / I-95', 'I-66']

--- a/src/lib/domain/public-location.ts
+++ b/src/lib/domain/public-location.ts
@@ -14,7 +14,8 @@
  * rule keeps out of `lib/domain`.
  */
 
-import type { SpotLocation } from './locations.ts'
+import type { SpotImage, SpotLocation } from './locations.ts'
+import { spotImage } from './locations.ts'
 
 export type PublicLocationSource = 'database' | 'directory'
 
@@ -38,6 +39,13 @@ export interface PublicLocation {
   linesTo: string[]
   communityUrl?: string
   notes?: string
+  /**
+   * Absent where no approved photograph exists — which is every spot today
+   * (issue #18, D-39). Resolved from the committed directory in *both* mappings
+   * below, because it is deliberately not a `locations` column: the row cannot
+   * supply it, and the two mappings must still produce the same record.
+   */
+  image?: SpotImage
   /** Which of the two answered. Rendered nowhere; load-bearing in a bug report. */
   source: PublicLocationSource
 }
@@ -95,8 +103,15 @@ export function publicLocationFromRow(row: LocationRow): PublicLocation {
     linesTo: row.lines_to ?? [],
     ...(row.community_url ? { communityUrl: row.community_url } : {}),
     ...(row.notes ? { notes: row.notes } : {}),
+    ...imageFor(row.slug),
     source: 'database',
   }
+}
+
+/** The one field the table cannot answer, so both mappings ask the directory. */
+function imageFor(slug: string): { image?: SpotImage } {
+  const image = spotImage(slug)
+  return image ? { image } : {}
 }
 
 export function publicLocationFromDirectory(location: SpotLocation): PublicLocation {
@@ -118,6 +133,7 @@ export function publicLocationFromDirectory(location: SpotLocation): PublicLocat
     linesTo: location.linesTo ?? [],
     ...(location.fbUrl ? { communityUrl: location.fbUrl } : {}),
     ...(location.notes ? { notes: location.notes } : {}),
+    ...(location.image ? { image: location.image } : {}),
     source: 'directory',
   }
 }

--- a/tests/spot-photos.test.mjs
+++ b/tests/spot-photos.test.mjs
@@ -1,0 +1,190 @@
+// Issue #18 — per-location photographs, and the media area that renders when
+// there is none.
+//
+// Today there is never one. All 27 assets under
+// sluglines.com/images/slugging_locations/ were pulled and inspected on
+// 2026-08-22 and every one is a satellite tile, a third-party transit or parking
+// schematic, an annotated aerial route diagram, or a promotional flyer. Zero are
+// photographs. Docs/asset-register.md carries the classification; D-39 the
+// reasoning.
+//
+// So the assertions here have two jobs. The ones over SPOT_LOCATIONS hold the
+// line as data: nothing may claim to be a photograph unless it came from the one
+// permitted path and is actually on disk. A fixture then carries an image through
+// the mapping, so the path that runs when #26 supplies real photographs is not
+// shipped never having carried one.
+
+import { strict as assert } from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { LEGACY_IMAGE_PREFIX, SPOT_LOCATIONS, spotImage } from '../src/lib/domain/locations.ts'
+import { publicLocationFromDirectory, publicLocationFromRow } from '../src/lib/domain/public-location.ts'
+
+const root = process.cwd()
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8')
+
+// -----------------------------------------------------------------------------
+// Every image the directory carries, whenever one exists
+// -----------------------------------------------------------------------------
+const withImage = SPOT_LOCATIONS.filter((location) => location.image)
+
+for (const location of withImage) {
+  const { image } = location
+  const where = `${location.slug}:`
+
+  assert.ok(
+    image.sourceUrl.startsWith(LEGACY_IMAGE_PREFIX),
+    `${where} migrated from ${image.sourceUrl} — only ${LEGACY_IMAGE_PREFIX} is permitted. ` +
+      'Some legacy pages also carry an lh5.googleusercontent.com avatar, which is a commenter, not a spot.'
+  )
+
+  // Self-hosted, always. A hotlink to sluglines.com dies with WordPress.
+  assert.ok(image.src.startsWith('/'), `${where} src must be a path under public/, not a URL`)
+  assert.equal(/^https?:/i.test(image.src), false, `${where} src must not be remote`)
+  assert.ok(
+    fs.existsSync(path.join(root, 'public', image.src.replace(/^\//, ''))),
+    `${where} ${image.src} is referenced but not present in public/`
+  )
+
+  // next/image needs both, or the box is not reserved and the Lighthouse CLS
+  // budget goes with it.
+  assert.ok(Number.isInteger(image.width) && image.width > 0, `${where} width`)
+  assert.ok(Number.isInteger(image.height) && image.height > 0, `${where} height`)
+  assert.ok(image.alt.trim().length > 0, `${where} alt text describes the spot`)
+  assert.match(image.fetchedAt, /^\d{4}-\d{2}-\d{2}$/, `${where} fetchedAt is an ISO date`)
+}
+
+// The finding, pinned as data. If this ever fails it means a photograph landed,
+// which is #26's job — update the count here in the same change.
+assert.equal(
+  withImage.length,
+  0,
+  `${withImage.length} spot(s) now carry a photograph. None did as of 2026-08-22 (D-39); ` +
+    'if #26 has supplied one, update this assertion in the change that added it.'
+)
+
+assert.equal(spotImage('Horner-Rd'), undefined, 'lookup is case-insensitive and returns nothing today')
+assert.equal(spotImage('no-such-spot'), undefined)
+
+// -----------------------------------------------------------------------------
+// The field is NOT a database column — 0004 must apply untouched
+// -----------------------------------------------------------------------------
+const seedScript = read('scripts/seed-locations.mjs')
+const seedColumns = /const SEED_COLUMNS = \[([\s\S]*?)\]/.exec(seedScript)
+
+assert.ok(seedColumns, 'seed-locations.mjs must declare SEED_COLUMNS')
+assert.equal(
+  /['"]image['"]/.test(seedColumns[1]),
+  false,
+  'image must stay out of SEED_COLUMNS: 0004 is generated from this module and guarded byte-for-byte'
+)
+
+const migration = read('supabase/migrations/0004_spot_locations_directory.sql')
+assert.equal(/\bimage\b/.test(migration), false, '0004 must carry no image column')
+
+// `locations` has no image column, so LOCATION_COLUMNS must not ask for one.
+const publicLocation = read('src/lib/domain/public-location.ts')
+assert.equal(
+  /LOCATION_COLUMNS[\s\S]{0,400}?image/.test(publicLocation),
+  false,
+  'the select list must not name a column the table does not have'
+)
+
+// -----------------------------------------------------------------------------
+// Both mappings resolve the image identically — the file's own stated invariant
+// -----------------------------------------------------------------------------
+const sample = SPOT_LOCATIONS[0]
+
+const fromDirectory = publicLocationFromDirectory(sample)
+const fromRow = publicLocationFromRow({
+  slug: sample.slug,
+  route_slug: sample.routeSlug,
+  name: sample.name,
+  corridor: sample.corridor,
+  direction: sample.direction,
+  county: sample.county,
+  destination: sample.destination,
+  description: sample.description,
+  latitude: sample.latitude,
+  longitude: sample.longitude,
+  is_active: sample.active,
+  peak_hours: sample.peakHours ?? null,
+  parking: sample.parking ?? null,
+  lines_from: sample.linesFrom ?? null,
+  lines_to: sample.linesTo ?? null,
+  community_url: sample.fbUrl ?? null,
+  notes: sample.notes ?? null,
+})
+
+assert.deepEqual(
+  fromRow.image,
+  fromDirectory.image,
+  'the row mapping resolves the image from the directory, so both produce the same record'
+)
+
+// Exercise the populated branch with a fixture, so the mapping that will run when
+// #26 supplies a photograph is not shipped never having carried one.
+const FIXTURE_IMAGE = {
+  src: '/spots/example.jpg',
+  width: 1200,
+  height: 900,
+  alt: 'Example spot',
+  sourceUrl: `${LEGACY_IMAGE_PREFIX}Example.jpg`,
+  fetchedAt: '2026-08-22',
+}
+
+const withFixture = publicLocationFromDirectory({ ...sample, image: FIXTURE_IMAGE })
+assert.deepEqual(withFixture.image, FIXTURE_IMAGE, 'a directory image survives the mapping intact')
+assert.ok(withFixture.image.sourceUrl.startsWith(LEGACY_IMAGE_PREFIX))
+assert.equal(publicLocationFromDirectory({ ...sample, image: undefined }).image, undefined)
+
+// -----------------------------------------------------------------------------
+// The media area: both branches, structurally
+// -----------------------------------------------------------------------------
+const photo = read('src/components/SpotPhoto.tsx')
+
+// The header explains the posture by naming the shapes it rejects — `<img>` among
+// them — so the negative assertion has to read the code and not the prose about it.
+// Same reason dashboard-fast-board.test.mjs strips comments before its bans.
+const photoCode = photo.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+assert.match(photo, /from 'next\/image'/, 'the populated branch uses next/image, not a bare <img>')
+assert.equal(/<img[\s>]/.test(photoCode), false, 'no raw <img>: it would ship an unsized asset')
+assert.match(photo, /width=\{image\.width\}/, 'explicit width')
+assert.match(photo, /height=\{image\.height\}/, 'explicit height')
+assert.match(photo, /sizes=/, 'responsive sizes, so a 360px slot does not fetch a 2600px file')
+
+// The 4:3 box is reserved in BOTH branches. That is the asset register's rule,
+// and it is what stops the page reflowing the day a photograph is added.
+assert.equal(
+  (photo.match(/aspect-\[4\/3\]/g) ?? []).length,
+  2,
+  'both the photograph and the no-photograph state reserve the same 4:3 area'
+)
+
+// The no-image state says what it is rather than implying a missing file.
+assert.match(photo, /No photograph of this spot yet/)
+assert.match(photo, /satellite view/, 'it names what it is deliberately not showing')
+assert.match(photo, /aria-hidden/, 'the drawn graphic is decorative and hidden from screen readers')
+
+const layout = read('src/components/SpotDetailLayout.tsx')
+assert.match(layout, /<SpotPhoto image=\{location\.image\} spotName=\{location\.name\} \/>/)
+
+// -----------------------------------------------------------------------------
+// public/ holds no image that no spot claims
+// -----------------------------------------------------------------------------
+const spotsDir = path.join(root, 'public', 'spots')
+const onDisk = fs.existsSync(spotsDir) ? fs.readdirSync(spotsDir) : []
+const claimed = new Set(withImage.map((location) => path.basename(location.image.src)))
+
+assert.deepEqual(
+  onDisk.filter((name) => !claimed.has(name)),
+  [],
+  'public/spots holds a file no spot references — an orphan nobody will notice going stale'
+)
+
+console.log(
+  `spot photos: ${withImage.length}/${SPOT_LOCATIONS.length} spots carry a photograph; ` +
+    `${SPOT_LOCATIONS.length - withImage.length} render the reserved no-photograph state`
+)


### PR DESCRIPTION
Closes #18

## The finding that changes what this issue is

Every asset under `sluglines.com/images/slugging_locations/` was pulled and **visually inspected** on 2026-08-22 — not classified from filenames. 27 distinct files, referenced by 25 of the 42 legacy spot pages. All 42 pages reachable, **no dead URL**.

**None of the 27 is a photograph.**

| Kind | Count | Evidence |
|---|---|---|
| Google satellite / aerial tile | 12 | Several carry a visible `Google` credit and `Map data ©2016 Google` inside the pixels, plus a `www.sluglines.com` watermark. `Route17.jpg` and `Mine_Road.jpg` are unannotated tiles. |
| Third-party transit or parking schematic | 8 | VDOT / VRE / WMATA / Fairfax County lot diagrams — bay listings, space counts, ADA and bicycle-parking legends. `Crystal_City_12th_St.jpg` and `Crystal_City_23rd_St.jpg` are the **same** WMATA map. |
| Annotated aerial route diagram | 6 | 2018–2019 change notices: *"Changes to Slug pickup location at the Pentagon going to Stafford"*, *"New traffic pattern at the pentagon starting feb 26 2018"*. |
| Promotional flyer | 1 | `21st-Street.jpg` — speech bubble, Sluglines logo, Facebook group URL, Twitter handle, `admin@SlugLines.com`. |
| **Photograph of a location** | **0** | — |

`Horner_Road.jpg` — the flagship spot — is a satellite tile with slug-line labels drawn on it. `Bobs.jpg` is a bus-bay schematic.

## Why nothing was migrated

The standing rule for this work is that spots without a photograph get a designed no-image state — *"not a broken img, not stretched filler, **not a satellite tile posing as a photograph**"*. The finding is that **every candidate is one**. Migrating them would be that exact failure, applied to 25 spots instead of avoided on 18.

Three independent lines agree, which is why this is not a close call:

1. **The tiles are Google Maps imagery.** `Docs/asset-register.md` already flags that *"embedded map imagery has separate terms"*, and Google's credit is baked into several files.
2. **The route diagrams are already classified `Historical only`** by that same register — *"Staffordboro and Pentagon route diagrams from 2018-2019 … operational directions may have changed"*. Two are dated 2018 in their own filenames. A 2018 traffic-change notice shown as a spot's current image tells a commuter something operational that may be years wrong.
3. **The schematics are third-party operator material.** `Docs/content-sources.md`: link to the operator rather than copy.

Same discipline as D-31 (a `null` coordinate is never guessed) and D-33 (`unavailable`, never a fabricated zero). An aerial view of a car park in a slot labelled *photograph of this spot* is a fabricated answer to the question the slot asks.

## The inherited audit was wrong, in an instructive way

#18 records *"32 legacy spots with a photo, 10 without"*. Real figure: **25 with an asset, 17 without**. The seven-spot gap is made up entirely of assets the issue's own guidance excludes:

| Excluded | Spots | Why |
|---|---|---|
| Image at `sluglines.com/images/`, not `…/slugging_locations/` | `franconia-springfield`, `landmark-mall`, `van-dorn-st` | Outside the permitted path |
| Only image is an `lh5.googleusercontent.com` avatar | `mark-center`, `navy-yard`, `rosslyn` | A commenter's face — **the trap the issue names** |
| Only image is `direction.png` | `telegraph-rd` | A UI icon, used on 8 pages |

25 + 3 + 3 + 1 = 32. **The audit counted the avatars it warned about.**

One more: the live site now references an asset the 2026-07-11 snapshot missed — `sydenstricker-rd` also loads `Saratoga.jpg`, the same schematic the `saratoga` page uses. Not a new photograph.

## What ships

- **`SpotLocation.image`** — typed `SpotImage` with `src` / `width` / `height` / `alt` / `sourceUrl` / `fetchedAt`. **Out of `SEED_COLUMNS`**, so `0004` is byte-identical: `sql:check` reports the same `7 migration(s), 173 statement(s), 0 violations` and `seed-locations --check` says up to date. No `locations` column, no new migration.
- **`SpotPhoto.tsx`** — the asset register's *"reserve a stable 4:3 media area, but show a neutral route graphic until a current approved photograph exists"*. `next/image` with explicit `width`/`height`/`sizes` in one branch; a drawn route graphic and a sentence in the other. **The 4:3 box is reserved in both**, so adding a photograph later reflows nothing and the empty state reads as complete rather than broken.
- **`tests/spot-photos.test.mjs`** — refuses any image whose `sourceUrl` is not under `slugging_locations/`, requires the file to exist in `public/`, bans a raw `<img>`, asserts both branches reserve 4:3, asserts `image` is absent from `SEED_COLUMNS` and from `0004`, checks `public/spots` holds no orphan, and carries a fixture through `publicLocationFromDirectory` so the populated path is not shipped never having run.
- Both mappings in `public-location.ts` resolve `image` from the committed directory — the table cannot supply it, and that file's stated invariant is that both mappings produce the same record.

## Done-when

- [x] `SpotLocation` has an optional image field; no `locations` column, no new migration
- [x] photos downloaded and self-hosted, never hotlinked — **vacuous: there are none.** The mechanism and the guard are in place
- [x] a test asserts every migrated image URL is under `sluglines.com/images/slugging_locations/`
- [x] spots without a photo render a designed no-image state — **all 50**, not 18
- [x] the 2026-07-11 audit re-verified against the live site; dead URLs and new photos reported — 0 dead, 1 new reference (a duplicate schematic)
- [x] served through `next/image` with explicit dimensions

## Follow-ups filed

- **#26** — scope corrected in a comment: **all 50 spots**, not 18. It now has a one-line-per-photo receiving end.
- **#39** — publish the diagrams **as maps**, labelled as such, once the third-party rights question is answered. They are genuinely useful; they are just not photographs.

## Gate

```
=== npm run sql:check === 7 migration(s), 173 statement(s), 0 violations
                          0004 is up to date (50 spots)
=== npm run lint ===      LINT=0        (1 pre-existing warning, untouched file)
=== npm run typecheck === TYPECHECK=0
=== npm run test ===      PASS=29 FAIL=0   TEST=0
                          spot photos: 0/50 carry a photograph; 50 render the reserved state
=== npm run build ===     BUILD=0  elapsed=137s   ✓ Compiled successfully
                          ƒ /spots/[slug]   5.34 kB / 101 kB
```

Baseline `N` moved 28/874 → 29/904; the #7 guard required the header update in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)