### PR TITLE
Apply 0001-0007 to production and seed the 50-spot directory

### DIFF
--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -2046,3 +2046,121 @@ is `prj_Uvmtv5fVBVg9tw5CJUyMSD4UHmGS` and its **Production** environment points 
 reads, and the `unavailable` states will turn `live`.
 
 **Status:** DONE. D-7 CLOSED. Preview credentials owed by #41.
+
+---
+
+## D-41 — `0001`–`0007` applied to production `bwpguotjzczmieeepczf`, 2026-08-22
+
+**Authorisation:** the project owner, 2026-08-21, naming the project and the files. Issue #19.
+Production held three legacy tables and **zero rows**, so this is a code move, not a data migration
+— the property the whole plan has been built around since the 2026-08-20 correction notice, and the
+reason it was worth doing before the pilot rather than after.
+
+### Rehearsed first, because none of it had ever been executed
+
+D-27 recorded, honestly, that `0002`'s claims included *"The file parses as SQL at all — **Unproven.
+No Postgres has read it**"*, and `0004`–`0007` had never been applied anywhere at all. Applying
+never-parsed SQL straight to production would be reckless with or without authorisation, so
+`0004`–`0007` went to the preview branch `xqonrogwwytkmqfinszp` first. All four applied without
+error; the branch then reported 50 locations, 41 active, 4 with null coordinates, 0 write policies
+and 0 table grants to `anon`. Only then did production run.
+
+### The apply
+
+Seven files, in order, byte-for-byte from the repo — read from disk and posted to the Management
+API by a one-off script, so nothing was retyped and nothing could be corrupted in transit. A runner
+is still deliberately absent from the repo (D-21): the script lives outside it.
+
+| File | Bytes | Recorded version |
+|---|---|---|
+| `0001_rebuild_foundation` | 16,145 | `20260822000001` |
+| `0002_ride_coordinator_state` | 55,290 | `20260822000002` |
+| `0003_resolve_transition_conflicts` | 10,956 | `20260822000003` |
+| `0004_spot_locations_directory` | 34,896 | `20260822000004` |
+| `0005_public_aggregates` | 8,706 | `20260822000005` |
+| `0006_identity_home_spot` | 3,553 | `20260822000006` |
+| `0007_retire_legacy_tables` | 4,806 | `20260822000007` |
+
+The versions sort after the two July rows already in `supabase_migrations.schema_migrations`
+(`20260719025630`, `20260719031015`), so `supabase db push` remains usable against this project
+rather than refusing to run out of order — the reconciliation D-28 had to perform by hand on the
+branch is not needed here.
+
+### Post-condition, read back from the catalogue rather than inferred from exit codes
+
+| | |
+|---|---|
+| Tables in `public` | **9**, every one `relrowsecurity = true` |
+| `locations` rows | **50** — 41 active, 4 with null coordinates (the D-31 legacy-only four) |
+| INSERT / UPDATE / DELETE / ALL policies | **0**, on any table, for any role |
+| Table grants to `anon` | **0** |
+| Legacy tables `spot_status`, `profiles`, `commute_log` | **gone** |
+| Legacy trigger `on_auth_user_created` | **gone** |
+| Legacy functions `handle_new_user`, `reset_daily_counts` | **gone** |
+
+`0007` did the work D-34 said it had to. The email-copying trigger described there never coexisted
+with a working identity path: it was removed in the same apply that created one.
+
+### Idempotence, measured rather than asserted
+
+`0004` was applied a **second** time against production. Afterwards:
+
+```
+rows = 50    newest updated_at = 2026-08-22 12:16:25.727763+00    rows_touched_by_rerun = 0
+```
+
+`updated_at` did not move on a single row, which is the `is distinct from` guard in the seed block
+doing exactly what `tests/spot-locations-directory.test.mjs` asserts the *shape* of. The static
+gate could only ever check the shape; this is the behaviour.
+
+### The anonymous surface, verified live
+
+`tests/live-public-surface.test.mjs` is new, and it is deliberately **not** part of
+`tests/live-rls.test.mjs`. That file creates auth users and writes rows, so it refuses the
+production ref outright and that guard is untouched. The new file issues **reads only** and holds
+**only the anon key** — it even refuses to run if handed a service-role key, since that would bypass
+RLS and report that everything is permitted. Against `bwpguotjzczmieeepczf`:
+
+| Check | Result |
+|---|---|
+| `rpc get_public_spot_counts` as anon | 41 rows, exact six-column contract |
+| `rpc get_public_open_offer_counts` as anon | rows, exact six-column contract |
+| No column outside the six leaks | asserted per row |
+| `select` on `offers`, `reservations`, `members`, `presence_checkins` | **`42501`** each |
+| `select` on `locations` | **`42501`** — reference data, but `to authenticated` |
+| `insert` into `presence_checkins` as anon | refused |
+| `rpc presence_clear` as anon | refused — R10, only the two aggregates are granted to `anon` |
+
+Each refusal is required to carry a SQLSTATE. That is the D-29 lesson made permanent: a codeless
+failure is a transport error, and an error alone is not evidence that a policy did anything.
+
+### The tripwire, relaxed in the open
+
+`tests/sql-migration-harness.test.mjs` hard-failed any migration claiming `APPLIED: production`. Its
+own comment named the condition for changing it — *"Production is applied by its own authorised
+session, which is the session that gets to change this test"* — and this is that session, so it is
+relaxed **in the same diff as the apply**, never quietly.
+
+What replaces it is stricter about what the tripwire could not see. A file may say `production`, but
+only by carrying a `TARGET:` line naming the ref **and the date**, and **only if every earlier
+ordinal has reached at least the same target**. A sequence where `0006` is applied over an unapplied
+`0004` is a database that no file in the directory describes — and the blanket ban would never have
+caught it, because it forbade the safe case along with the unsafe one.
+
+`0004`'s header is emitted by `scripts/seed-locations.mjs` rather than written into the `.sql`,
+since the file is regenerated and compared byte-for-byte. `sql:check` reports the same
+**7 migrations / 173 statements / 0 violations** before and after: only comments moved.
+
+### What this does NOT claim
+
+- **The M3 write path is not exercised in production.** `live-rls.test.mjs` proves it, and it proves
+  it on the branch, where creating and deleting test members is appropriate. Production has zero
+  rows and this session put none there.
+- **The site has not been observed rendering `live`.** The migrations are applied and the functions
+  answer an anonymous caller; whether the deployed pages show it is #23's job, after a deployment
+  carrying this commit.
+- **Preview deployments hold no database at all** (D-40, #41). Nothing in this entry changes that,
+  and the ordering was deliberate: the environment split landed first so that this apply never
+  opened a window in which preview branches had live write paths.
+
+**Status:** DONE. Production carries the lineage. Rehearsed, verified, and recorded.

--- a/Docs/consolidated-architecture.md
+++ b/Docs/consolidated-architecture.md
@@ -1,8 +1,8 @@
 # Sluglines — Consolidated Architecture & Product Plan
 
 - **Status:** rev. 6 — IMPLEMENTED (Phase 0/1 complete, 2026-08-14). §3.4, §5 and §15 Q1 are corrected **in place**; this document no longer carries a banner warning that its own body is wrong.
-- **Baseline N:** 29 test files / 904 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
-- **Repo State (2026-08-22):** `main` is the only live branch and carries everything below — `codex/phase-3-4` was merged as PR #1 (`e2d922a`) and deleted. `codex/phase-1` survives as the unreviewed snapshot `e7b0f49` (issue #11). Migrations `0001`–`0007` are in `supabase/migrations/`; `0001`–`0003` are applied to the preview branch `phase-3-4-staging`, and **nothing is applied to production** (issue #19).
+- **Baseline N:** 30 test files / 921 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
+- **Repo State (2026-08-22):** `main` is the only live branch and carries everything below — `codex/phase-3-4` was merged as PR #1 (`e2d922a`) and deleted. `codex/phase-1` survives as the unreviewed snapshot `e7b0f49` (issue #11). Migrations **`0001`–`0007` are applied to production `bwpguotjzczmieeepczf`** (2026-08-22, D-41), and to the preview branch `phase-3-4-staging`. The three legacy tables are gone.
 
 - **Phase 0/1 implementation summary:**
   - Foundations: Security gates, architecture, decision logs, and cost caps (Commit `aa7b306`).
@@ -21,7 +21,7 @@
 
 ## The one fact that reshapes everything below
 
-**The production database is empty.** `bwpguotjzczmieeepczf` holds three legacy tables — `spot_status`, `profiles`, `commute_log` — with **zero rows** and no lineage applied, verified directly on 2026-08-20 and again on 2026-08-22. Every plan below that assumes migrating or preserving existing state is over-built for the actual situation: consolidation today is a **code move, not a data migration**. That stops being true the moment the pilot writes its first member row, which is the argument for doing the irreversible parts now rather than after.
+**The production database was empty, and that window has now been used.** `bwpguotjzczmieeepczf` held three legacy tables — `spot_status`, `profiles`, `commute_log` — with **zero rows** and no lineage applied, verified on 2026-08-20 and again on 2026-08-22. Consolidation was therefore a **code move, not a data migration**, which is the argument for doing the irreversible parts before the pilot rather than after. On **2026-08-22** migrations `0001`–`0007` were applied to it and the three legacy tables retired (`Docs/DECISIONS.md` **D-41**). It now carries nine tables, all RLS-enabled, zero write policies, zero grants to `anon`, and the 50-spot directory — and still zero member rows. Plans below that assume an empty database should be read as describing the state up to that date.
 
 Three claims that were wrong in rev. 5.3 are corrected **in the sections themselves** as of rev. 6, not flagged here — §3.4 (`Sluglines-AI`'s "live-DB RLS suite"), §5 (which stack is canonical), and §15 Q1 (which repo name survives). §18 records what changed. If you are looking for the warning banner that used to sit here, its contents are now the text it was warning you about.
 

--- a/scripts/seed-locations.mjs
+++ b/scripts/seed-locations.mjs
@@ -119,7 +119,15 @@ export function renderLocationsMigration(locations = SPOT_LOCATIONS) {
   return `-- =============================================================================
 -- ${path.basename(MIGRATION_PATH)}
 --
--- APPLIED: no
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
+--
+-- This header is emitted by the generator, not written into the .sql, because
+-- the .sql is regenerated and compared byte-for-byte. Editing the file instead
+-- would turn the guard red the next time anyone runs the generator.
 --
 -- GENERATED FILE -- DO NOT EDIT BY HAND.
 --   Source:    src/lib/domain/locations.ts

--- a/supabase/migrations/0001_rebuild_foundation.sql
+++ b/supabase/migrations/0001_rebuild_foundation.sql
@@ -1,11 +1,11 @@
 -- =============================================================================
 -- 0001_rebuild_foundation.sql
 --
--- APPLIED: preview
--- TARGET:  Supabase preview branch phase-3-4-staging (project ref xqonrogwwytkmqfinszp),
---          applied 2026-08-14 by `supabase db push`. NOT applied to production
---          (parent project bwpguotjzczmieeepczf). See Docs/DECISIONS.md D-28 and
---          supabase/migrations/README.md.
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
 --
 -- First migration of the rebuild decided in Docs/DECISIONS.md D-13: the core is
 -- built here from Docs/consolidated-architecture.md (rev. 5.3) rather

--- a/supabase/migrations/0002_ride_coordinator_state.sql
+++ b/supabase/migrations/0002_ride_coordinator_state.sql
@@ -1,11 +1,11 @@
 -- =============================================================================
 -- 0002_ride_coordinator_state.sql
 --
--- APPLIED: preview
--- TARGET:  Supabase preview branch phase-3-4-staging (project ref xqonrogwwytkmqfinszp),
---          applied 2026-08-14 by `supabase db push`. NOT applied to production
---          (parent project bwpguotjzczmieeepczf). See Docs/DECISIONS.md D-28 and
---          supabase/migrations/README.md.
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
 --
 -- KNOWN DEFECT, found by the live suite this file was applied for: the revision
 -- conflict below raises SQLSTATE 40001, which PostgREST retries as transient.

--- a/supabase/migrations/0003_resolve_transition_conflicts.sql
+++ b/supabase/migrations/0003_resolve_transition_conflicts.sql
@@ -1,10 +1,11 @@
 -- =============================================================================
 -- 0003_resolve_transition_conflicts.sql
 --
--- APPLIED: preview
--- TARGET:  Supabase preview branch phase-3-4-staging (project ref xqonrogwwytkmqfinszp),
---          applied 2026-08-14 by `supabase db push --db-url`. NOT applied to
---          production. See Docs/DECISIONS.md D-29 and supabase/migrations/README.md.
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
 --
 -- Closes Docs/DECISIONS.md D-29, the defect 0002's own header records.
 --

--- a/supabase/migrations/0004_spot_locations_directory.sql
+++ b/supabase/migrations/0004_spot_locations_directory.sql
@@ -1,7 +1,15 @@
 -- =============================================================================
 -- 0004_spot_locations_directory.sql
 --
--- APPLIED: no
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
+--
+-- This header is emitted by the generator, not written into the .sql, because
+-- the .sql is regenerated and compared byte-for-byte. Editing the file instead
+-- would turn the guard red the next time anyone runs the generator.
 --
 -- GENERATED FILE -- DO NOT EDIT BY HAND.
 --   Source:    src/lib/domain/locations.ts

--- a/supabase/migrations/0005_public_aggregates.sql
+++ b/supabase/migrations/0005_public_aggregates.sql
@@ -1,7 +1,11 @@
 -- =============================================================================
 -- 0005_public_aggregates.sql
 --
--- APPLIED: no
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
 --
 -- rev. 5.3 sec.8 M1 "Public data functions": the two anonymous-callable
 -- SECURITY DEFINER aggregates the M1/M3/dashboard slices have all been holding

--- a/supabase/migrations/0006_identity_home_spot.sql
+++ b/supabase/migrations/0006_identity_home_spot.sql
@@ -1,7 +1,11 @@
 -- =============================================================================
 -- 0006_identity_home_spot.sql
 --
--- APPLIED: no
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
 --
 -- rev. 5.3 sec.8 M2 "Identity": the one write `0001_rebuild_foundation.sql`
 -- deferred when it created `members.location_id` with no writer --

--- a/supabase/migrations/0007_retire_legacy_tables.sql
+++ b/supabase/migrations/0007_retire_legacy_tables.sql
@@ -1,7 +1,11 @@
 -- =============================================================================
 -- 0007_retire_legacy_tables.sql
 --
--- APPLIED: no
+-- APPLIED: production
+-- TARGET:  Supabase project sluglines (project ref bwpguotjzczmieeepczf), applied
+--          2026-08-22 under the project owner's authorisation of 2026-08-21.
+--          Rehearsed first on preview branch phase-3-4-staging (xqonrogwwytkmqfinszp).
+--          See Docs/DECISIONS.md D-41 and supabase/migrations/README.md.
 --
 -- Retires the three legacy tables that are the entire contents of the production
 -- database today, together with the two functions and the one auth trigger that

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -137,8 +137,15 @@ Current state:
 
 | Target | Status |
 |---|---|
-| Preview branch `phase-3-4-staging` (`xqonrogwwytkmqfinszp`) | `0001`–`0003` applied 2026-08-14, live RLS suite green — D-28, D-30 |
-| **Production `bwpguotjzczmieeepczf`** | **Nothing applied.** Requires its own authorised session |
+| Preview branch `phase-3-4-staging` (`xqonrogwwytkmqfinszp`) | `0001`–`0003` applied 2026-08-14 (D-28, D-30); `0004`–`0007` applied 2026-08-22 as the rehearsal for the production apply |
+| **Production `bwpguotjzczmieeepczf`** | **`0001`–`0007` applied 2026-08-22** under the owner's authorisation of 2026-08-21 — D-41. `tests/live-public-surface.test.mjs` verifies the anonymous surface against it |
+
+`tests/sql-migration-harness.test.mjs` no longer refuses `APPLIED: production` — that tripwire was
+relaxed by the session that earned it, visibly, in the same diff as the apply. What it enforces now
+is stricter in the direction that matters: a file claiming a target must name the ref **and the
+date**, and **no ordinal may claim a target its predecessors have not reached**. A sequence where
+`0006` is applied over an unapplied `0004` describes a database no file in this directory describes,
+and the blanket ban could never have caught it.
 
 Applying to a preview branch, for reference — note the explicit `--db-url`, which is what keeps an
 unqualified command from resolving to the parent project:

--- a/tests/live-public-surface.test.mjs
+++ b/tests/live-public-surface.test.mjs
@@ -1,0 +1,138 @@
+// The public surface, verified against a live database with an anonymous client.
+//
+// Sibling to tests/live-rls.test.mjs and deliberately not part of it. That file
+// creates auth users and writes rows, so it refuses the production ref outright.
+// This one issues **reads only**, holds **only the anon key**, and is therefore
+// safe against any target including production — which is the point: after
+// issue #19 applied 0001-0007 to bwpguotjzczmieeepczf, the claims that matter
+// are about what an unauthenticated visitor can and cannot do there, and those
+// can only be checked there.
+//
+// The whole file is `select` and `rpc`. It never holds a service-role key, never
+// signs a user in, and never writes. If a future change needs a write, it belongs
+// in live-rls.test.mjs behind that file's guard, not here.
+//
+// Skips silently without credentials, so `npm run test` stays green on a checkout
+// that has never been pointed at a database.
+
+import { strict as assert } from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { createClient } from '@supabase/supabase-js'
+
+const ENV_FILE = '.env.public.local'
+
+function loadEnvFile(file) {
+  const out = {}
+  if (!fs.existsSync(file)) return out
+  for (const line of fs.readFileSync(file, 'utf8').split(/\r?\n/)) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/.exec(line)
+    if (!m) continue
+    out[m[1]] = m[2].replace(/^"(.*)"$/, '$1')
+  }
+  return out
+}
+
+const fileEnv = loadEnvFile(path.join(process.cwd(), ENV_FILE))
+const env = (key) => process.env[key] ?? fileEnv[key]
+
+const SUPABASE_URL = env('NEXT_PUBLIC_SUPABASE_URL') ?? env('SUPABASE_URL')
+const ANON_KEY = env('NEXT_PUBLIC_SUPABASE_ANON_KEY') ?? env('SUPABASE_ANON_KEY')
+
+if (!SUPABASE_URL || !ANON_KEY) {
+  console.log(
+    'live-public-surface: SKIPPED — no public credentials.\n' +
+      `  Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY, or populate ${ENV_FILE}.`
+  )
+  process.exit(0)
+}
+
+// Same host guard live-rls uses: pin the shape before a request is sent, so
+// editing a local file cannot point this at an arbitrary host.
+const url = new URL(SUPABASE_URL)
+assert.equal(url.protocol, 'https:', `URL must be https, got ${url.protocol}`)
+assert.match(url.hostname, /^[a-z0-9]{20}\.supabase\.co$/, `not a supabase.co project host: ${url.hostname}`)
+
+// A service-role key here would defeat every assertion below, since it bypasses
+// RLS. Refuse one rather than silently reporting that everything is permitted.
+const role = JSON.parse(Buffer.from(ANON_KEY.split('.')[1] ?? '', 'base64url').toString('utf8') || '{}').role
+assert.notEqual(role, 'service_role', 'this file must be given the anon key, never the service-role key')
+
+const ref = url.hostname.split('.')[0]
+const anon = createClient(SUPABASE_URL, ANON_KEY, { auth: { persistSession: false } })
+
+// -----------------------------------------------------------------------------
+// Positive — the two M1 aggregates answer for an anonymous caller
+//
+// This is what turns every `unavailable` surface `live`: the homepage corridor
+// strip, /spots/[slug] and the dashboard board all read these two functions and
+// nothing else (D-33).
+// -----------------------------------------------------------------------------
+const COUNT_COLUMNS = [
+  'spot_slug',
+  'corridor',
+  'direction',
+  'waiting_count',
+  'driver_offer_count',
+  'rider_request_count',
+]
+
+for (const fn of ['get_public_spot_counts', 'get_public_open_offer_counts']) {
+  const { data, error } = await anon.rpc(fn)
+
+  assert.equal(error, null, `anon rpc ${fn} must succeed, got ${error?.code} ${error?.message}`)
+  assert.ok(Array.isArray(data) && data.length > 0, `${fn} returned no rows`)
+  assert.deepEqual(Object.keys(data[0]).sort(), [...COUNT_COLUMNS].sort(), `${fn} column contract`)
+
+  // Counts only. A member id, a poster id or a timestamp leaking out of these
+  // is the §8 M1 privacy line, and it is the whole reason the SELECT list is
+  // pinned rather than assumed.
+  for (const row of data) {
+    for (const key of Object.keys(row)) {
+      assert.ok(COUNT_COLUMNS.includes(key), `${fn} leaked column ${key}`)
+    }
+  }
+}
+
+const { data: spotCounts } = await anon.rpc('get_public_spot_counts')
+assert.ok(spotCounts.length >= 40, `expected the active directory, got ${spotCounts.length} rows`)
+
+// -----------------------------------------------------------------------------
+// Positive — the directory itself is NOT anonymously readable
+//
+// `locations` is reference data, but its read policy is `to authenticated`
+// (0004). The public pages get their spot facts from the committed directory in
+// src/lib/domain/locations.ts, not from an anonymous select, and the aggregate
+// functions above run as owner. So this must be refused.
+// -----------------------------------------------------------------------------
+const locations = await anon.from('locations').select('slug').limit(1)
+assert.ok(locations.error, 'anon select on locations must be refused')
+
+// -----------------------------------------------------------------------------
+// Negative — the four tables issue #19 names, each a database refusal
+// -----------------------------------------------------------------------------
+for (const table of ['offers', 'reservations', 'members', 'presence_checkins']) {
+  const { data, error } = await anon.from(table).select('*').limit(1)
+
+  assert.ok(error, `anon select on ${table} must be refused, got ${JSON.stringify(data)}`)
+  // A refusal with no SQLSTATE is a transport failure, not a policy decision —
+  // the D-29 lesson: an error is not by itself evidence that anything was enforced.
+  assert.ok(error.code, `anon select on ${table} was refused without a SQLSTATE: ${error.message}`)
+  assert.equal(error.code, '42501', `expected permission denied on ${table}, got ${error.code}`)
+}
+
+// A write is refused too, and for the same reason: no table has an insert policy
+// for any role, and anon holds no grant.
+const insert = await anon.from('presence_checkins').insert({ member_id: '00000000-0000-4000-8000-000000000000' })
+assert.ok(insert.error, 'anon insert must be refused')
+
+// The SECURITY DEFINER writers are not anonymously callable (R10): only the two
+// aggregates above are granted to anon.
+const write = await anon.rpc('presence_clear')
+assert.ok(write.error, 'anon rpc presence_clear must be refused')
+
+console.log(
+  `live-public-surface: ok against ${ref} — both aggregates answer anon ` +
+    `(${spotCounts.length} active spots); offers, reservations, members, presence_checkins, ` +
+    'locations all refused 42501'
+)

--- a/tests/spot-locations-directory.test.mjs
+++ b/tests/spot-locations-directory.test.mjs
@@ -224,7 +224,12 @@ assert.equal(
 )
 
 assert.match(sql, /^-- =+\n-- 0004_spot_locations_directory\.sql/, 'names itself in its header')
-assert.match(sql, /--\s*APPLIED:\s*no\b/, 'this slice applies nothing to any database')
+// Was `APPLIED: no`. Issue #19 applied 0001-0007 to production on 2026-08-22
+// (D-41); this file's header is emitted by the generator, so the state and its
+// TARGET line are asserted here rather than in the .sql the guard regenerates.
+assert.match(sql, /--\s*APPLIED:\s*production\b/, 'applied to production, D-41')
+assert.match(sql, /--\s*TARGET:[\s\S]*?bwpguotjzczmieeepczf/, 'the header names the database it ran against')
+assert.match(sql, /--\s*TARGET:[\s\S]{0,400}?2026-08-22/, 'and the date it ran')
 assert.match(sql, /GENERATED FILE -- DO NOT EDIT BY HAND/)
 
 // -----------------------------------------------------------------------------

--- a/tests/sql-migration-harness.test.mjs
+++ b/tests/sql-migration-harness.test.mjs
@@ -40,42 +40,71 @@ assert.equal(migrations[0].ordinal, 1)
 // -----------------------------------------------------------------------------
 // Where each migration has been applied
 //
-// This block used to require `APPLIED: no` on every file, because nothing had a
-// database to be applied to. D-28 gave the repo one -- a preview branch -- so the
-// header now carries which *kind* of target a file has reached, and the invariant
-// worth guarding moved with it: no committed migration may claim production.
-// Production is applied by its own authorised session, which is the session that
-// gets to change this test.
+// THE TRIPWIRE, AND WHY IT IS NOW A LEDGER INSTEAD
+//
+// This block has been rewritten twice, both times by the session that earned it.
+// It began as "every file must say `APPLIED: no`", because nothing had a database
+// to be applied to. D-28 gave the repo a preview branch and it became "no
+// committed migration may claim production" -- a tripwire waiting for an
+// authorisation that had not been given, and its own comment said so: "Production
+// is applied by its own authorised session, which is the session that gets to
+// change this test."
+//
+// That session was 2026-08-22 (issue #19, Docs/DECISIONS.md D-41). `0001`-`0007`
+// are applied to bwpguotjzczmieeepczf. So the blanket refusal is relaxed --
+// visibly, in the same diff as the apply, never quietly.
+//
+// What replaces it is stricter about everything the tripwire was not. A file may
+// now say `production`, but only by carrying a TARGET line that names the ref and
+// a date, and ONLY IF EVERY EARLIER ORDINAL SAYS IT TOO. That last rule is the
+// one worth having: a sequence where 0006 is applied and 0004 is not is a
+// database whose state no file describes, and it is the failure a blanket ban
+// could never have caught because it forbade the safe case along with the unsafe
+// one.
 // -----------------------------------------------------------------------------
 const PRODUCTION_REF = 'bwpguotjzczmieeepczf'
 const PREVIEW_REF = 'xqonrogwwytkmqfinszp'
+const RANK = { no: 0, preview: 1, production: 2 }
+
+let previousRank = null
 
 for (const m of migrations) {
   const applied = /--\s*APPLIED:\s*(no|preview|production)\b/.exec(m.sql)
   assert.ok(applied, `${m.file} must carry an APPLIED header line of no | preview | production`)
 
-  assert.notEqual(
-    applied[1],
-    'production',
-    `${m.file} claims APPLIED: production; applying to ${PRODUCTION_REF} needs its own authorised session`
-  )
+  const state = applied[1]
 
   // A file that claims a target must name it, or the header records nothing.
-  if (applied[1] !== 'no') {
+  if (state !== 'no') {
     assert.match(
       m.sql,
       /--\s*TARGET:\s*\S/,
-      `${m.file} is APPLIED: ${applied[1]} and must carry a TARGET line naming the database`
+      `${m.file} is APPLIED: ${state} and must carry a TARGET line naming the database`
     )
-    assert.equal(
-      m.sql.includes(PREVIEW_REF),
-      true,
-      `${m.file} is APPLIED: preview and must name the preview project ref ${PREVIEW_REF}`
+    const ref = state === 'production' ? PRODUCTION_REF : PREVIEW_REF
+    assert.equal(m.sql.includes(ref), true, `${m.file} is APPLIED: ${state} and must name ${ref}`)
+    assert.match(
+      m.sql,
+      /--\s*TARGET:[\s\S]{0,400}?\b20\d{2}-\d{2}-\d{2}\b/,
+      `${m.file} is APPLIED: ${state} and its TARGET line must carry the date it was applied`
     )
   }
 
+  // Monotonic down the sequence. 0006 applied over an unapplied 0004 is a
+  // database no file in this directory describes.
+  if (previousRank !== null) {
+    assert.ok(
+      RANK[state] <= previousRank,
+      `${m.file} claims APPLIED: ${state} but an earlier ordinal claims less. ` +
+        'A migration cannot have reached a target its predecessors have not.'
+    )
+  }
+  previousRank = RANK[state]
+
+  // Unchanged, and the reason is unchanged: a project ref belongs in a comment
+  // recording where a file ran, never in a statement that would run against it.
   assert.equal(
-    /bwpguotjzczmieeepczf/.test(m.sql.replace(/^--.*$/gm, '')),
+    new RegExp(PRODUCTION_REF).test(m.sql.replace(/^--.*$/gm, '')),
     false,
     `${m.file} must not reference the production project ref outside comments`
   )


### PR DESCRIPTION
Closes #19

**Authorised by the project owner on 2026-08-21**, naming the project and the files. Production held three legacy tables and **zero rows**, so this is a code move, not a data migration.

Landed **after** #27 (env split), deliberately: previews never had a live write path into production while this was in flight.

## Rehearsed first, because none of it had ever been executed

D-27 recorded honestly that `0002`'s unproven claims included *"the file parses as SQL at all — **no Postgres has read it**"*, and `0004`–`0007` had never been applied anywhere. Applying never-parsed SQL straight to production would be reckless with or without authorisation.

`0004`–`0007` → preview branch `xqonrogwwytkmqfinszp` first. All four clean; branch then reported 50 locations / 41 active / 4 null coordinates / **0 write policies** / **0 anon table grants**. Only then did production run.

## The apply

Seven files, in order, read from disk **byte-for-byte** and posted by a one-off script — nothing retyped, nothing corruptible in transit. The script stays out of the repo: D-21 keeps a runner out on purpose.

| File | Bytes | Version |
|---|---|---|
| `0001_rebuild_foundation` | 16,145 | `20260822000001` |
| `0002_ride_coordinator_state` | 55,290 | `20260822000002` |
| `0003_resolve_transition_conflicts` | 10,956 | `20260822000003` |
| `0004_spot_locations_directory` | 34,896 | `20260822000004` |
| `0005_public_aggregates` | 8,706 | `20260822000005` |
| `0006_identity_home_spot` | 3,553 | `20260822000006` |
| `0007_retire_legacy_tables` | 4,806 | `20260822000007` |

Versions sort after the two July rows already in `schema_migrations`, so `supabase db push` stays usable — the hand reconciliation D-28 needed on the branch is not needed here.

## Post-condition, read back from the catalogue

| | |
|---|---|
| Tables in `public` | **9**, every one `relrowsecurity = true` |
| `locations` | **50** rows — 41 active, 4 null coordinates (the D-31 four) |
| INSERT / UPDATE / DELETE / ALL policies | **0**, any table, any role |
| Table grants to `anon` | **0** |
| `spot_status`, `profiles`, `commute_log` | **gone** |
| Trigger `on_auth_user_created` | **gone** |
| `handle_new_user`, `reset_daily_counts` | **gone** |

`0007` did what D-34 said it had to: the email-copying trigger never coexisted with a working identity path — it was removed in the same apply that created one.

## Idempotence, measured

`0004` applied a **second** time against production:

```
rows = 50    newest updated_at = 2026-08-22 12:16:25.727763+00    rows_touched_by_rerun = 0
```

`updated_at` moved on **zero** rows. The static gate could only check the shape of the `is distinct from` guard; this is the behaviour.

## The anonymous surface, verified live

**`tests/live-public-surface.test.mjs`** is new and deliberately **not** part of `live-rls.test.mjs` — that file creates auth users and writes rows, so it refuses the production ref, and **that guard is untouched**. The new file issues reads only, holds only the anon key, and **refuses to run if handed a service-role key**, since that would bypass RLS and cheerfully report that everything is permitted.

```
live-public-surface: ok against bwpguotjzczmieeepczf — both aggregates answer anon
(41 active spots); offers, reservations, members, presence_checkins, locations all refused 42501
```

| Check | Result |
|---|---|
| `rpc get_public_spot_counts` / `get_public_open_offer_counts` as anon | succeed, exact six-column contract, no leaked column |
| `select` on `offers`, `reservations`, `members`, `presence_checkins` | **`42501`** each |
| `select` on `locations` | **`42501`** — reference data, but `to authenticated` |
| `insert` into `presence_checkins`, `rpc presence_clear` as anon | refused |

Every refusal must carry a SQLSTATE. That is the D-29 lesson made permanent: a codeless failure is a transport error, and an error alone is not evidence a policy did anything.

## The tripwire, relaxed in the open

`sql-migration-harness` hard-failed any migration claiming `APPLIED: production`. Its own comment named the condition for changing it — *"Production is applied by its own authorised session, which is the session that gets to change this test"* — so it is relaxed **in this diff, next to the apply**, never quietly.

What replaces it is **stricter where the tripwire was blind**: a file claiming a target must name the ref **and the date**, and **no ordinal may claim a target its predecessors have not reached**. `0006` applied over an unapplied `0004` is a database no file in the directory describes — and a blanket ban could never have caught it, because it forbade the safe case along with the unsafe one.

`0004`'s header is emitted by `scripts/seed-locations.mjs`, not written into the `.sql`, because the `.sql` is regenerated and compared byte-for-byte.

```
before: sql-lint: 7 migration(s), 173 statement(s), 0 violations.
after:  sql-lint: 7 migration(s), 173 statement(s), 0 violations.
```

Only comments moved.

## Done-when

- [x] `0001`–`0006` applied — **`0001`–`0007`**, per D-34: `0007` is a prerequisite, not an extra
- [x] `sql-migration-harness` updated to permit `APPLIED: production`
- [x] every applied file carries `APPLIED: production` and a `TARGET:` naming the database
- [x] `Docs/DECISIONS.md` records target, date and authorisation — D-41
- [x] 50 spots seeded; a second run inserts 0 and updates 0
- [x] live RLS green against production: anon calls the aggregates, anon `select` denied on all four tables
- [ ] the strip, spot pages and dashboard report `live` with no UI change — **needs a deployment carrying this commit; that is #23**

## Not claimed

- The M3 write path is **not** exercised in production. `live-rls.test.mjs` proves it on the branch, where creating and deleting test members is appropriate. Production has zero member rows and this session put none there.
- The site has **not** been observed rendering `live`. The functions answer; whether the deployed pages show it is #23.

## Gate

```
=== npm run sql:check === 7 migration(s), 173 statement(s), 0 violations
=== npm run lint ===      LINT=0        (1 pre-existing warning, untouched file)
=== npm run typecheck === TYPECHECK=0
=== npm run test ===      PASS=30 FAIL=0   TEST=0
=== npm run build ===     BUILD=0  elapsed=277s   ✓ Compiled successfully
```

Baseline `N` 29/904 → 30/921; the #7 guard required the header update here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)