### PR TITLE
Health endpoint and Sev-1 definition; external monitoring reported not done

### DIFF
--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -2192,3 +2192,61 @@ After a redeploy (`sluglines-9kb91ocwn…`, aliased to `sluglines.vercel.app`, t
 
 The zeros are measured: production has zero presence rows and zero offers. D-33's distinction
 holds on a real page — these render as "Quiet right now", not as "unavailable".
+
+---
+
+## D-42 — Sev-1 definition, and the health endpoint that makes it observable
+
+Issue #21. Later gates reference the Sev-1 definition, so it has to exist before they can.
+
+### Sev-1
+
+> **The product is unusable for members during a peak window.**
+
+Concretely, any one of these, during a peak window:
+
+| # | Condition |
+|---|---|
+| 1 | **Auth is down** — `/api/auth/send-otp` or `/api/auth/verify-otp` fails for all callers, so no member can sign in |
+| 2 | **The board is down** — `/`, `/spots/**` or `/dashboard` 5xx, or the M1 aggregates fail, so no member can see what is happening at a spot |
+| 3 | **The database is unreachable** — `/api/health` returns 503 on its `database` check |
+| 4 | **The write path is refusing valid transitions** — an offer or reservation cannot be created, confirmed or cancelled by an entitled member |
+
+**Peak windows** are the §13 commute windows: **05:30–09:30** and **15:30–19:30** US/Eastern, Monday to Friday. Outside them the same failure is Sev-2 — it still gets fixed, it does not get someone out of bed.
+
+**Explicitly NOT Sev-1**, so the definition stays usable:
+
+- Counts rendering `unavailable`. That is a designed degradation (D-33): the board still lists every line, it just declines to claim a number it did not measure. It is Sev-2.
+- A spot page with no photograph — the reserved no-image state is the intended render for all 50 (D-39).
+- A preview deployment being broken. Preview holds no database (D-40).
+- The sweeps not running. Real, tracked as #46, and invisible to a member because both read paths compute expiry at read time.
+
+The distinction the list is built around: **Sev-1 is "a commuter standing at a lot cannot use this to decide", not "something is wrong".**
+
+### `/api/health`
+
+`GET /api/health`, and its whole design rule is that it may only report what it just observed. It calls both M1 aggregates through the anonymous path a visitor uses, returns **200** when every check passes and **503** when any does, sets `no-store`, and names the deployment (`VERCEL_GIT_COMMIT_SHA`, env, region) so a green check proves *this* build is up rather than that some build is.
+
+Zero rows from the directory is treated as a failure, not a success: the query succeeded but the public surface is empty, which is condition 2 above.
+
+It carries no member data and structurally cannot — the only reads are the two counts-only functions, and it reports a row *count*, never a row. `tests/health-endpoint.test.mjs` pins that, along with the 503 and the absence of any synthesised timestamp.
+
+### The part that is NOT done, and why
+
+The issue asks for **an external check every minute, alerting the operator, test-fired at least once with the receipt recorded**. That is not done and was not attempted.
+
+Every option requires **creating an account on a third-party service**, which this session does not do. It is also not something to fake: a monitor configured but never test-fired is precisely what the issue's own wording rules out — *"an untested alert is not monitoring"*.
+
+What is ready for whoever configures it:
+
+| | |
+|---|---|
+| URL to watch | `https://<production-domain>/api/health` |
+| Interval | 60s |
+| Alert on | any non-200; the endpoint returns 503 with a JSON body naming the failed check |
+| Second URL | `/` — catches an edge or routing failure that never reaches the app |
+| Note | Vercel Authentication is currently on for all `.vercel.app` URLs (#47), so an external monitor cannot reach the site until a custom domain exists (#25) or that protection is relaxed |
+
+That last row is the real blocker and is worth stating plainly: **there is currently no publicly reachable URL for an external monitor to hit.** Configuring one before #25 would produce a check that alerts on 401 forever.
+
+**Status:** Sev-1 DEFINED. Health endpoint DONE. External monitoring and its test-fire **NOT DONE** — needs an account and a public URL.

--- a/Docs/consolidated-architecture.md
+++ b/Docs/consolidated-architecture.md
@@ -1,7 +1,7 @@
 # Sluglines — Consolidated Architecture & Product Plan
 
 - **Status:** rev. 6 — IMPLEMENTED (Phase 0/1 complete, 2026-08-14). §3.4, §5 and §15 Q1 are corrected **in place**; this document no longer carries a banner warning that its own body is wrong.
-- **Baseline N:** 31 test files / 930 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
+- **Baseline N:** 32 test files / 946 assertion call sites, all passing (recounted 2026-08-22, D-35). This line is machine-checked — `tests/baseline-n.test.mjs` re-measures the repo and fails if it and this header disagree, so `N` cannot drift again without the change that moved it saying so. Supersedes D-25's "12 files / 99 assertions", which was stale by more than 2×.
 - **Repo State (2026-08-22):** `main` is the only live branch and carries everything below — `codex/phase-3-4` was merged as PR #1 (`e2d922a`) and deleted. `codex/phase-1` survives as the unreviewed snapshot `e7b0f49` (issue #11). Migrations **`0001`–`0007` are applied to production `bwpguotjzczmieeepczf`** (2026-08-22, D-41), and to the preview branch `phase-3-4-staging`. The three legacy tables are gone.
 
 - **Phase 0/1 implementation summary:**

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from 'next/server'
+import {
+  PUBLIC_OPEN_OFFER_COUNTS_FUNCTION,
+  PUBLIC_SPOT_COUNTS_FUNCTION,
+} from '@/lib/domain/public-counts'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * `GET /api/health` — the endpoint the external uptime check watches (issue #21).
+ *
+ * WHAT IT IS ALLOWED TO SAY
+ * ---------------------------------------------------------------------------
+ * Only things it has just observed. A health endpoint that reports `ok` because
+ * it did not look is worse than no health endpoint: it converts an outage into a
+ * green dashboard. So every field below is either a measurement taken during
+ * this request or an explicit `null` with a reason — the same discipline as
+ * `unavailable` counts never rendering as zero (D-33) and null coordinates never
+ * being guessed (D-31).
+ *
+ * It carries no member data and cannot: the only database call it makes is the
+ * anonymous M1 aggregate, which returns counts and nothing else, and it reports
+ * a row count rather than any row.
+ *
+ * STATUS CODES, chosen so a dumb external monitor is enough
+ * ---------------------------------------------------------------------------
+ *   200  every check passed
+ *   503  at least one check the product cannot work without has failed
+ *
+ * An uptime check that only reads the status line is therefore correct without
+ * parsing the body, which is what makes a one-minute external check useful.
+ */
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+interface Check {
+  ok: boolean
+  detail: string
+  latencyMs?: number
+}
+
+export async function GET() {
+  const startedAt = Date.now()
+  const checks: Record<string, Check> = {}
+
+  // --- the database, through the same anonymous path a visitor uses ----------
+  const dbStartedAt = Date.now()
+  try {
+    const supabase = createClient()
+    const { data, error } = await supabase.rpc(PUBLIC_SPOT_COUNTS_FUNCTION)
+
+    if (error) {
+      checks.database = {
+        ok: false,
+        detail: `${PUBLIC_SPOT_COUNTS_FUNCTION} failed: ${error.code ?? 'no sqlstate'}`,
+        latencyMs: Date.now() - dbStartedAt,
+      }
+    } else {
+      const rows = Array.isArray(data) ? data.length : 0
+      checks.database = {
+        // Zero rows means the directory is not seeded, which is an outage of the
+        // public surface even though the query succeeded.
+        ok: rows > 0,
+        detail: `${PUBLIC_SPOT_COUNTS_FUNCTION} returned ${rows} active spot rows`,
+        latencyMs: Date.now() - dbStartedAt,
+      }
+    }
+  } catch (error) {
+    checks.database = {
+      ok: false,
+      detail: `supabase client unavailable: ${error instanceof Error ? error.message : 'unknown'}`,
+      latencyMs: Date.now() - dbStartedAt,
+    }
+  }
+
+  // --- the second aggregate, because the board needs both -------------------
+  const offersStartedAt = Date.now()
+  try {
+    const { error } = await createClient().rpc(PUBLIC_OPEN_OFFER_COUNTS_FUNCTION)
+    checks.offerCounts = {
+      ok: !error,
+      detail: error ? `${PUBLIC_OPEN_OFFER_COUNTS_FUNCTION} failed: ${error.code ?? 'no sqlstate'}` : 'ok',
+      latencyMs: Date.now() - offersStartedAt,
+    }
+  } catch (error) {
+    checks.offerCounts = {
+      ok: false,
+      detail: `unreachable: ${error instanceof Error ? error.message : 'unknown'}`,
+      latencyMs: Date.now() - offersStartedAt,
+    }
+  }
+
+  const ok = Object.values(checks).every((check) => check.ok)
+
+  return NextResponse.json(
+    {
+      status: ok ? 'ok' : 'degraded',
+      checkedAt: new Date(startedAt).toISOString(),
+      durationMs: Date.now() - startedAt,
+      // Which build answered. Without this a green check proves a deployment is
+      // up, not that *this* deployment is up.
+      deployment: {
+        commit: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+        environment: process.env.VERCEL_ENV ?? 'local',
+        region: process.env.VERCEL_REGION ?? null,
+      },
+      checks,
+      /**
+       * The sweeps rev. 5.3 §6 specifies — `sweep_expired_presence()` and
+       * `offer_expire_sweep()` — exist in production but **nothing runs them**:
+       * `pg_cron` is not installed (verified 2026-08-22). There is therefore no
+       * last-run timestamp to report, and this says so rather than omitting the
+       * field and letting its absence read as "fine". Tracked as issue #46.
+       */
+      scheduledJobs: {
+        supported: false,
+        detail: 'pg_cron is not installed; sweep_expired_presence and offer_expire_sweep have never run',
+        lastRunAt: null,
+      },
+    },
+    {
+      status: ok ? 200 : 503,
+      headers: { 'cache-control': 'no-store, max-age=0' },
+    }
+  )
+}

--- a/tests/api-routes.test.mjs
+++ b/tests/api-routes.test.mjs
@@ -83,10 +83,18 @@ function routeSource(route) {
   return fs.readFileSync(file, 'utf8')
 }
 
-// Every route file on disk must be one of the eleven — a stray route handler
-// under src/app/api is an unreviewed write path. `auth/` is excluded: it is
-// the rev. 5.3 §8 M2 identity surface, a sibling scope with its own exact
-// inventory check in `auth-otp-routes.test.mjs`.
+// Read-only routes, which are a different category from the eleven above and
+// are listed rather than lumped in with them: they take no body, perform no
+// transition, and are exempt from the write-path assertions below.
+//
+//   health  GET /api/health — the issue #21 monitoring endpoint. Its own
+//           properties are pinned in tests/health-endpoint.test.mjs.
+const READ_ONLY_ROUTES = ['health']
+
+// Every route file on disk must be one of the eleven, or a named read-only
+// route — a stray route handler under src/app/api is an unreviewed write path.
+// `auth/` is excluded: it is the rev. 5.3 §8 M2 identity surface, a sibling
+// scope with its own exact inventory check in `auth-otp-routes.test.mjs`.
 function collectRoutes(dir, prefix = '') {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     if (entry.isDirectory() && prefix === '' && entry.name === 'auth') return []
@@ -97,7 +105,19 @@ function collectRoutes(dir, prefix = '') {
 }
 
 const onDisk = collectRoutes(apiDir).sort()
-assert.deepEqual(onDisk, [...ALL_ROUTES].sort(), 'src/app/api holds exactly the eleven §8 M3 routes, plus auth/**')
+assert.deepEqual(
+  onDisk,
+  [...ALL_ROUTES, ...READ_ONLY_ROUTES].sort(),
+  'src/app/api holds exactly the eleven §8 M3 routes plus the named read-only routes, plus auth/**'
+)
+
+// A read-only route must not export POST: that is what keeps this category a
+// category rather than a hole in the inventory above.
+for (const route of READ_ONLY_ROUTES) {
+  const source = fs.readFileSync(path.join(apiDir, route, 'route.ts'), 'utf8')
+  assert.match(source, /export async function GET\(/, `${route} must be a GET`)
+  assert.equal(/export async function POST\(/.test(source), false, `${route} is read-only and must not export POST`)
+}
 
 for (const route of ALL_ROUTES) {
   const source = routeSource(route)

--- a/tests/health-endpoint.test.mjs
+++ b/tests/health-endpoint.test.mjs
@@ -1,0 +1,56 @@
+// `/api/health` — structural assertions over the route the external uptime check
+// watches (issue #21).
+//
+// This file cannot execute the handler: it needs `next/headers`, which only
+// exists inside a request. What it can do is pin the properties that make the
+// endpoint *useful as a monitor*, all of which are visible in the source and all
+// of which a well-meaning refactor could silently remove.
+//
+// The one that matters most is the status code. An uptime check that only reads
+// the status line has to be correct without parsing the body — an endpoint that
+// always answers 200 and hides the failure in JSON turns an outage into a green
+// dashboard, which is worse than having no endpoint at all.
+
+import { strict as assert } from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const route = fs.readFileSync(path.join(root, 'src/app/api/health/route.ts'), 'utf8')
+const code = route.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+// --- it actually looks -------------------------------------------------------
+assert.match(code, /\.rpc\(PUBLIC_SPOT_COUNTS_FUNCTION\)/, 'it queries the database rather than reporting ok blindly')
+assert.match(code, /\.rpc\(PUBLIC_OPEN_OFFER_COUNTS_FUNCTION\)/, 'both aggregates the board needs are checked')
+assert.match(code, /from '@\/lib\/domain\/public-counts'/, 'the function names come from the domain contract, not string literals')
+
+// --- it fails loudly ---------------------------------------------------------
+assert.match(code, /status: ok \? 200 : 503/, 'a failed check must be a 503, readable from the status line alone')
+assert.match(code, /rows > 0/, 'an empty directory is an outage of the public surface, not a success')
+assert.match(code, /cache-control/, 'a cached health check reports the past')
+assert.match(code, /'no-store/, 'and no-store is how it stops doing that')
+assert.match(code, /export const dynamic = 'force-dynamic'/, 'never prerendered')
+
+// --- it says which build answered -------------------------------------------
+assert.match(code, /VERCEL_GIT_COMMIT_SHA/, 'a green check must identify the deployment it came from')
+
+// --- it never reports a fact it did not measure ------------------------------
+assert.match(code, /scheduledJobs/, 'the sweeps are reported')
+assert.match(code, /lastRunAt: null/, 'as null, because pg_cron is not installed and they have never run (#46)')
+assert.match(code, /supported: false/)
+assert.equal(
+  /lastRunAt: new Date\(\)/.test(code),
+  false,
+  'a last-run timestamp must never be synthesised from the current time'
+)
+
+// --- it carries no member data ----------------------------------------------
+for (const forbidden of ['members', 'presence_checkins', 'offers', 'reservations', 'phone', 'display_name']) {
+  assert.equal(
+    new RegExp(`from\\('${forbidden}'\\)`).test(code),
+    false,
+    `the health endpoint must not select from ${forbidden}`
+  )
+}
+
+console.log('health endpoint: 503 on failure, no-store, deployment identified, no synthesised timestamps')


### PR DESCRIPTION
Closes #21

## Sev-1 — D-42

Later gates reference this definition, so it exists first.

> **The product is unusable for members during a peak window.**

Any of: **auth down** (no member can sign in) · **board down** (`/`, `/spots/**`, `/dashboard` 5xx, or the M1 aggregates fail) · **database unreachable** (`/api/health` 503s its `database` check) · **write path refusing valid transitions**.

**Peak windows:** 05:30–09:30 and 15:30–19:30 US/Eastern, weekdays — the §13 commute windows. Outside them the same failure is Sev-2: it still gets fixed, it does not get someone out of bed.

The entry also says what is **not** Sev-1, which is what keeps the definition usable:

- Counts rendering `unavailable` — a designed degradation (D-33); the board still lists every line, it declines to claim a number it did not measure
- A spot with no photograph — the intended render for all 50 (D-39)
- A broken preview deployment — preview holds no database (D-40)
- The sweeps not running — real (#46), invisible to a member because both read paths compute expiry at read time

The line it is built around: **"a commuter standing at a lot cannot use this to decide"**, not "something is wrong".

## `/api/health`

Its design rule is that it may only report what it just observed — a health endpoint that answers `ok` because it did not look converts an outage into a green dashboard.

| | |
|---|---|
| Checks | both M1 aggregates, through the anonymous path a visitor uses |
| Status | **200** all passed · **503** any failed — correct from the status line alone, so a dumb one-minute monitor is enough |
| Empty directory | treated as **failure**: the query succeeded but the public surface is empty |
| Caching | `no-store` — a cached health check reports the past |
| Identity | `VERCEL_GIT_COMMIT_SHA`, env, region — without it a green check proves *some* build is up, not this one |
| Data | reads only counts-only functions; reports a row **count**, never a row |

## The sweeps have never run — #46

Production has `sweep_expired_presence()` and `offer_expire_sweep()` and **`pg_cron` is not installed**:

```
pg_cron_installed = 0     sweep_functions = 2
```

Both are granted to nobody (correctly — they run as the scheduler), so with no scheduler they are unreachable by anything. The endpoint reports that rather than omitting it:

```json
"scheduledJobs": { "supported": false, "lastRunAt": null,
  "detail": "pg_cron is not installed; sweep_expired_presence and offer_expire_sweep have never run" }
```

The test forbids synthesising that timestamp from the current time. Invisible to members today because both read paths compute expiry at read time — but it is a retention problem the moment real members check in.

## The route inventory had to move deliberately

`api-routes.test.mjs` pinned the exact set of files under `src/app/api`, so adding one failed the suite. Rather than widening the assertion, **read-only routes are now a named category**, and a route in it must export `GET` and must **not** export `POST`. That keeps the category from becoming a hole in the write-path inventory it exists to protect.

## NOT DONE — external monitoring

The issue asks for an external check every minute, alerting the operator, **test-fired at least once with the receipt recorded**. Not done, not attempted, not faked.

1. Every option requires **creating an account on a third-party service**.
2. **There is no publicly reachable URL to watch.** Vercel Authentication is on for `all_except_custom_domains` and the project has no custom domain, so every URL 401s. A monitor configured today would alert on 401 forever — filed as **#47**.

Faking it is specifically ruled out by the issue's own wording: *"an untested alert is not monitoring."* D-42 records the exact configuration — URL, interval, alert condition, second URL — for whoever sets it up once #25 or #47 provides a public address.

## Gate

```
=== npm run lint ===      LINT=0        (1 pre-existing warning, untouched file)
=== npm run typecheck === TYPECHECK=0
=== npm run test ===      PASS=32 FAIL=0   TEST=0
=== npm run build ===     BUILD=0  elapsed=96s   ƒ /api/health
```

Baseline `N` 31/930 → 32/946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)