### PR TITLE
ci: bump both codeql-action refs to v4.37.7 together, superseding #65

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
           # security-and-quality is a superset of the default security queries.
@@ -43,7 +43,7 @@ jobs:
       # No build step: the javascript-typescript extractor analyses source directly,
       # so a Next.js build is not required and would only add failure surface.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:javascript-typescript'
 


### PR DESCRIPTION
Dependabot's #65 bumps `github/codeql-action/analyze` to v4.37.7 and leaves
`github/codeql-action/init` on v3.37.8. `init` and `analyze` are sub-paths of one repository and
share a commit SHA, and CodeQL refuses the split:

```
##[error]Loaded a configuration file for version '3.37.8', but running version '4.37.7'
##[error]analyze post-action step failed: Loaded a configuration file for version '3.37.8', but running version '4.37.7'
```

Both CodeQL checks failed on #65 for that reason and nothing else. `.github/workflows/static-analysis.yml`
lines 37 and 46 now carry the same v4.37.7 SHA, which is the whole fix.

This is a predictable consequence of the #34 posture — pin every action to a SHA, keep Dependabot on
to move the pins. The pin is per-`uses:` line, so an action whose sub-paths appear on two lines gets
bumped half-way and fails. Worth knowing it will recur for any other action referenced more than once.

No major is being rolled forward silently here: v4.37.7 is exactly what #65 already proposed, applied
to both lines instead of one.

**Supersedes #65**, which should be closed once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
