### PR TITLE
Docs: record what shipped on 2026-08-22

### DIFF
--- a/Docs/2026-08-22-shipped.md
+++ b/Docs/2026-08-22-shipped.md
@@ -1,0 +1,124 @@
+# What shipped — 2026-08-22
+
+**Status:** RECORD. A single day as it stood at close; not updated afterwards. Open work named
+here lives in the issue tracker, which is where it changes.
+**Recorded:** 2026-08-22, at `5e69e0d`.
+**Repo:** `sluglines` (canonical per the override in `Docs/DECISIONS.md`).
+**Range:** `e2d922a` (2026-08-21 00:16) → `5e69e0d` (2026-08-22 17:37).
+
+---
+
+## Totals
+
+| Measure | Count |
+|---|---|
+| Commits on `main` | 22 |
+| PRs merged | 22 |
+| Issues closed | 15 |
+| Issues opened | 3 |
+| Issues open at close | 20 |
+
+Production deployment `dpl_JDuVLgbBZCmCDCvjVAiMYTDaGJna` is `READY` at `5e69e0d`. All six
+workflows — `audit`, `ci`, `secret-scan`, `static-analysis`, `e2e`, `lighthouse` — pass on that
+commit.
+
+---
+
+## Database and schema
+
+- **One migration lineage settled** (#29). This repo's `0001`–`0007` is the schema; the competing
+  lineage and the legacy tables are retired.
+- **`0001`–`0007` applied to production** `bwpguotjzczmieeepczf`, and the 50-spot directory
+  seeded (#44). `0008` followed the same day.
+- **`pg_cron` installed and both sweeps scheduled** (#54). `sweep_expired_presence` and
+  `offer_expire_sweep` had existed since `0001`/`0002`, each with a comment deferring its
+  scheduling, and neither had ever run. The schedule lives in `supabase/operations/`, not the
+  migration sequence, so it does not schedule production's sweeps onto every preview branch.
+
+## CI and gates
+
+- **The test suite and a build now run in CI** (#28), on a portable runner. Before today neither
+  did.
+- **Lighthouse budgets and a both-palette WCAG AA contrast gate** (#45).
+- **Baseline test count recounted** to 28 files / 872 sites and made machine-checked (#30), so it
+  cannot go stale silently again.
+- **Browser security headers, commit-pinned Actions, and a browser harness** (#54). CSP ships
+  report-only with the blocker named — Next's bootstrap still needs `'unsafe-inline'` — and a test
+  holds `CSP_REPORT_ONLY` true while that is so. All 16 Action refs moved to SHAs. The new 34-test
+  Playwright harness found four real defects on its first run, one of them a day-old defect in the
+  header work it shipped alongside.
+
+## Identity and isolation
+
+- **OTP abuse controls applied** (#53), closing D-8, pending since Phase 0. The resend cooldown is
+  D-8's number exactly; the verify cap deliberately is not, because GoTrue's control is per IP and
+  D-8 asks per number — substituting one for the other silently is the failure this log refuses.
+- **Vercel environments split off the production Supabase project** (#42).
+
+## Content and legacy surface
+
+- **All 165 legacy routes verified against the deployed edge**, pre-DNS (#51).
+- **Spot photograph field and no-image state built** (#40) — and nothing migrated, with the reason
+  recorded rather than the gap left implicit.
+- **Five dead components deleted** (#38), all reading tables D-13 dropped.
+- **`codex/phase-1` triaged** (#37): asset register adopted, four issues filed, branch archived.
+
+## Decisions and documents
+
+- **Architecture doc cut to rev. 6** and renamed off its dated path (#32) — it is a living
+  document, so it should never have carried a date.
+- **The `tmp/` decisions addendum folded into `DECISIONS.md`** (#31), scratch paths ignored.
+- **PITR recorded as blocked-with-reason** (#50): the plan is Pro, `pitr_enabled` is false, and
+  buying it is spend. The decidable half — writing down the ~24-hour RPO as something to accept or
+  reject — is done.
+- **`/api/health` added and Sev-1 defined** (#48), with the external monitor reported as *not*
+  done rather than implied.
+
+---
+
+## The last seven commits
+
+`1802b0d` onward, all merged this evening.
+
+- **#54 merged** — the post-P2 hardening PR above, after two items were added to
+  `Docs/2026-08-22-transplant-scoping-prompt.md`: **item 7**, UI integration, because
+  `Sluglines-AI` has no shell to bring across (its `app/layout.tsx` is still create-next-app) while
+  this repo has a full chromed site; and **item 8**, AI enable/disable, framed as *off by default
+  plus spend bounds* rather than as a feature flag, because the kill switch already exists and
+  already works — `lib/ai/agent.ts` checks `ai_skill_enabled('global')` before any model call.
+  Item 4 gained the authed-only vs anonymous-free-tier decision with its real cost attached.
+- **Six dependency and CI bumps merged** — `@supabase/ssr` 0.3.0 → 0.12.4 (#57), and majors for
+  `actions/upload-artifact` (#62), `gitleaks/gitleaks-action` (#63), `actions/setup-node` (#64) and
+  `actions/checkout` (#66).
+- **#68 opened and merged.** Dependabot's #65 bumped `github/codeql-action/analyze` to v4.37.7 and
+  left `init` on v3.37.8. They are sub-paths of one repository sharing a commit SHA, and CodeQL
+  rejects the split. Both refs now carry the same SHA. This is structural, not a one-off: #34 pins
+  every action per `uses:` line, so any action referenced twice gets bumped half-way. It will
+  recur.
+- **Four Dependabot PRs closed** — #58, #59, #60, #61 — each a fragment of one migration rather
+  than an independent bump.
+
+### Issues opened
+
+| Issue | Why |
+|---|---|
+| #55 | The durable, cross-instance rate-limit store. After D-45 the per-number OTP cap is enforced only by `src/lib/api/rate-limit.ts`, a module-level `Map` — per serverless instance, reset on every redeploy. |
+| #56 | AI turn caps and per-turn C1 enforcement. `costs.md` C1 and C2 are both PENDING with no instrument; `/api/agent` has no rate limit and no turn cap, and every model class routes to `claude-opus-5`. |
+| #67 | The framework upgrade as one coordinated bundle. Four of five dependency PRs failed individually, which is CI evidence for the ADR's "cannot be done incrementally" claim. |
+
+---
+
+## State at close
+
+**Verified this session:** the commits are on `main`; all six workflows pass on `5e69e0d`; the
+production deployment carries that SHA; `0001`–`0008` are recorded as applied to production in the
+migrations ledger.
+
+**Not verified, and deliberately so:** that the site *serves*. Vercel Authentication returns 302 to
+`vercel.com/sso-api` for every `.vercel.app` URL (#47), and the Protection Bypass secret that would
+let automation through does not exist. DNS has not cut over (#25). Phone auth is off in production
+— `external_phone_enabled` is false (#52) — so the entire M2 identity surface cannot function. Each
+is a decision or an owner-performed step, not a regression.
+
+**Still ahead of the transplant:** the framework bundle (#67) is the prior phase; the schema
+re-expression is the largest and least visible piece; #56 depends on #55.


### PR DESCRIPTION
A dated record of a single day — 22 commits, `e2d922a` to `5e69e0d` — filed under the convention
`Docs/` already uses for one-moment files (`2026-08-20-adr-...`, `2026-08-22-supabase-auth-config.md`).
It will never be edited again, which is what earns it the date; the living documents in that
directory correctly have none.

Open work is referenced by issue number rather than restated, so the tracker stays the only place
it changes. There is no checklist in here.

The **State at close** section is the part worth reading. It separates what was verified this
session — commits on `main`, six green workflows on `5e69e0d`, the production deployment carrying
that SHA, `0001`–`0008` recorded applied in the migrations ledger — from what was not, which is
that the site serves. It does not: Vercel Authentication returns 302 for every `.vercel.app` URL
(#47), DNS has not cut over (#25), and `external_phone_enabled` is false (#52). Each is a decision
or an owner-performed step rather than a regression, and recording that distinction is the point.

Docs only. No code, no migrations, no database touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
