### PR TITLE
Docs: session handoff record for 2026-08-22/23

### DIFF
--- a/Docs/2026-08-23-handoff.md
+++ b/Docs/2026-08-23-handoff.md
@@ -1,0 +1,117 @@
+# Session handoff — 2026-08-22/23
+
+**Status:** RECORD. One session as it stood at close; not updated afterwards. Every piece of open
+work named here lives in the issue tracker, which is where it changes.
+**Recorded:** 2026-08-23, at `5ec17d0`.
+**Repo:** `sluglines`. **Production:** `bwpguotjzczmieeepczf`, migrations `0001`–`0010` applied.
+
+---
+
+## What this session was
+
+It began as a review of `Docs/2026-08-22-transplant-scoping-prompt.md` — specifically whether the
+AI module could be switched on and off — and ended having rewritten every spot page's content from
+the legacy site and applied two migrations to production. The path between those two points was not
+planned; each step was the next thing the previous step made obvious.
+
+Nine PRs merged: #54, #57, #62, #63, #64, #66, #68, #70, #71, #73, #74, #75, #76.
+
+## The through-line
+
+`sluglines.com` is still a live WordPress site. Everything built here is unreachable from it —
+Vercel Authentication blocks every `.vercel.app` URL (#47) and DNS has not cut over (#25). That is
+the frame for all of the below: this is a site being assembled beside the one still running.
+
+## Shipped
+
+**Transplant brief.** Produce items 7 (UI integration) and 8 (AI enable/disable, framed as *off by
+default plus spend bounds*) added, plus the authed-only vs anonymous-free-tier decision under item
+4. The kill switch already exists and works — `lib/ai/agent.ts` checks `ai_skill_enabled('global')`
+before any model call — so item 8 is about the bound, not the switch.
+
+**Dependencies and CI.** `@supabase/ssr` 0.3.0 → 0.12.4, and majors for `checkout`, `setup-node`,
+`upload-artifact`, `gitleaks-action`, `codeql-action`. Dependabot's `codeql-action` PR bumped
+`analyze` but not `init`, which CodeQL rejects outright; #68 moved both to one SHA. That failure is
+structural — #34 pins per `uses:` line, so any action referenced twice gets half-bumped — and will
+recur.
+
+**Legacy transit diagrams.** 8 of the 27 legacy assets, self-hosted under `public/spots/`,
+captioned as diagrams and never as photographs, with `object-contain` so the legend survives. 19
+held out: 12 Google Maps aerials (Google's credit and terms), 6 dated 2018–2019 route notices, 1
+promotional flyer carrying a contact address. D-58.
+
+**Per-spot content.** All 42 legacy spot pages re-extracted and merged into the directory —
+description 38, peak hours 39, parking 26, lines-from 38, lines-to 21. Merge semantics: legacy wins
+where it has a value, the existing value survives where the page is silent, so nothing was emptied.
+D-59.
+
+**A deadlock resolved on the way.** `0004` is generated from `lib/domain/locations.ts` and guarded
+byte-for-byte, *and* is `APPLIED: production` where the README forbids editing. Those rules were
+compatible only while the directory never changed. `supabase/migrations/0004.seed-snapshot.json`
+freezes `0004`'s inputs, so the guard proves `0004` is the file its own inputs generate and the live
+module is free to move. Content moves in new ordinals now.
+
+**Anonymous reads.** `get_public_location` (`0010`), a `security definer` function on the reviewed
+allowlist. The literal ask — `grant select on locations to anon` — could not be done: RLS would
+refuse every row (returning an empty result, not an error), and sql-lint R5 rejects any policy
+naming `anon`. `anon` gained a function, not a table; `has_table_privilege` for direct select is
+still false. D-60.
+
+**Both migrations applied**, `0009` then `0010`, in that order because reversing them would have
+silently regressed every spot page. Verified by an md5 over the five refreshed columns across all
+50 rows, computed in Postgres and compared against the same digest computed from the module: both
+`e4527efd7b99d980255beb5a399db8d1`. D-61.
+
+## What went wrong, and what caught it
+
+Recorded because the pattern is more useful than the individual mistakes.
+
+**I contradicted `Docs/asset-register.md` twice and was wrong both times.** I sampled three of 27
+image assets, found they did not match the register's summary line, and concluded the document was
+wrong. Its per-file table described exactly what I had found. A sample cannot establish that a
+classification of a heterogeneous set is wrong — landing on one category is the expected result.
+
+**I read `main` when an open PR held the newer truth.** An issue was filed describing a defect
+PR #54 had already fixed, on a branch I had committed to earlier in the same session.
+
+**A blind string replace reached an identifier.** Normalising the legacy site's three spellings of
+`L'Enfant` hit `routeSlug: 'LEnfant-Plaza'` — a live URL. The directory's own slug invariant caught
+it on the next test run.
+
+**Two content defects reached the migration and were caught by reading it.** Section labels and
+corridor headings inside destination lists (#74), and a heading plus a bus route in
+`route-610-mine-rd`'s destinations (#75) — which rendered as *"you can slug to Public
+Transportation"*. Nothing in CI could catch these: every gate in this repo is structural, and these
+were content. They surfaced only because applying a data migration by hand forces you to read the
+data.
+
+## Open work — all of it in the tracker
+
+Filed this session: **#72** (closed by `0010`), **#55**, **#56**, **#67**, **#77**, **#78**.
+
+| Issue | What it is |
+|---|---|
+| #78 | `0009` is applied but absent from `supabase_migrations`; `db push` will call it pending |
+| #77 | Public Transportation (40 pages) and External links (37) have no field to migrate into |
+| #67 | Next 16 / React 19 / Tailwind 4 as one coordinated bundle — the transplant's prior phase |
+| #55 | Durable rate-limit store; the current limiter is per-instance and resets on redeploy |
+| #56 | AI turn caps and per-turn C1 enforcement; depends on #55 |
+| #26, #39 | Both corrected this session — see the comments, the counts in the issue bodies are stale |
+| #25, #47, #52 | The three that gate anything being publicly reachable. Owner-performed. |
+
+**Nothing outstanding is recorded only here.** If it is not in the tracker, it is not owed.
+
+## State at close
+
+`main` at `5ec17d0`. Zero open PRs. 22 open issues. Production deployment carries that commit;
+all six workflows green on it. `0001`–`0010` applied. Spot pages serve the rewritten legacy
+content through `get_public_location`, with 8 carrying a transit diagram and 42 the reserved
+no-diagram state.
+
+Verified this session, not assumed: the commits are on `main`, the workflows pass on that SHA,
+`/api/health` reports the same commit in production with the database reachable and both sweeps
+healthy, and the live Bob's page still carries the closure notice, the 685-space breakdown, both
+relocation instructions and the diagram.
+
+Not verified, and deliberately: that `sluglines.com` serves any of it. It does not, and will not
+until #25.


### PR DESCRIPTION
A dated record, filed under the convention `Docs/` uses for one-moment files. It will never be edited again, which is what earns it the date.

**Every piece of open work it names is in the issue tracker**, and it says so explicitly: *"Nothing outstanding is recorded only here. If it is not in the tracker, it is not owed."* Two items that existed only inside decision entries were filed as #77 and #78 before this was written, and the stale counts in #26 and #39 were corrected by comment rather than restated here.

The **what went wrong** section is deliberate. Four failures, kept because the pattern is more useful than the individual mistakes:

- contradicting `Docs/asset-register.md` from a three-file sample, twice, and being wrong both times
- reading `main` when an open PR held the newer truth
- a blind string replace reaching `routeSlug: 'LEnfant-Plaza'`, a live URL
- two content defects no structural gate could catch, which surfaced only because applying a data migration by hand forces you to read the data

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)