### PR TITLE
Apply the setup audit: AGENTS.md, CLAUDE.md, portable settings, intent, record move

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git status *)",
+      "Bash(npm run test *)",
+      "Bash(npm test *)",
+      "Bash(npm run lint *)",
+      "Bash(npm run typecheck *)",
+      "Bash(npm run build *)",
+      "Bash(npm run sql:check *)",
+      "Bash(npm run e2e *)",
+      "Bash(npm run audit:check *)",
+      "Bash(npx tsc --noEmit *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh run watch *)",
+      "Bash(gh run view *)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Bash(npm run seed:locations *)",
+      "Bash(supabase db push *)"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Sluglines Project Rules
+
+HOV-3 carpool coordination for Northern Virginia. Next.js 16 App Router on Vercel, Supabase (Postgres, Auth, Realtime), Tailwind. This repo is the canonical implementation repo (`Docs/DECISIONS.md` D-2); the application core is **rebuilt here from the rev. 6 specification, not transplanted** from `Sluglines-AI` (D-13, decided by the human 2026-08-14). `CLAUDE.md` is a one-line import of this file so that Claude Code, Codex and Hermes read the same rules.
+
+## Gates
+
+Run as six independent gates, never one `&&` chain:
+
+```
+npm run test        # node scripts/run-tests.mjs — unit + schema harness; live-* suites skip without .env.preview.local
+npm run lint
+npm run typecheck
+npm run build
+npm run sql:check   # scripts/sql-lint.mjs + seed-locations --check
+npm run e2e         # Playwright, desktop + mobile Chromium
+```
+
+CI runs `ci`, `audit`, `secret-scan`, `static-analysis`, `e2e` and `lighthouse` on every PR (`.github/workflows/`). `Docs/consolidated-architecture.md`'s header carries the baseline test count `N`, and `tests/baseline-n.test.mjs` fails if the repo and the header disagree — a change that adds or removes tests updates the header in the same PR.
+
+## Hard constraints
+
+- **Migrations are append-only and nothing here applies them.** Read `supabase/migrations/README.md` before writing SQL. `sql-lint` enforces R1–R12 (default-deny RLS, no client write policies, `search_path` pinned, explicit revokes). Applying a migration is a deliberate, owner-authorised act against a named target; a file marked `APPLIED: production` is never edited except its header comments.
+- **Never point anything at the production project ref** (`bwpguotjzczmieeepczf`) from a session. Live suites refuse it by design; keep it that way.
+- **`Docs/DECISIONS.md` is append-only.** Each entry states the decision, its evidence and a status of `ADOPTED`, `DONE`, `PENDING` or `BLOCKED`. Nothing is inferred; an unverifiable fact is recorded as `PENDING` with what would close it.
+- **Content preservation.** The 400+ built routes, the legacy redirect inventory and `src/lib/{spot-directory,legacy-content,site-content,...}.ts` survive every restructure unchanged in behaviour; no slice may reduce the passing test set to satisfy a restructure (D-13).
+- **Public surface tokens.** The §10 palette is enforced by `tests/public-surface-tokens.test.mjs`; no `sky-*` or `slate-950` on a public page. Authenticated surfaces (`/login`, `/verify`, `/onboarding`, `/dashboard`, `FastBoard`) are not yet migrated — see `Docs/2026-09-01-handoff-public-surface-rest.md` for why.
+- **`AI/` is isolated.** Work under `AI/` must not modify or reinterpret the existing site unless an integration is explicitly approved through a decision entry. `Sluglines-AI` (separate repo) is reference and documentation only.
+- Source chat exports are research inputs only; never production or training data.
+
+## Definition of done
+
+An item closes when the change has been **seen working at the deployed URL** by a person — the production deployment on Vercel, or the preview the PR names — and the evidence (URL, timestamp, what was observed) is on the issue. Green CI closes nothing: `sluglines.com` is still the WordPress site until DNS cuts over (#25) and Vercel Authentication blocks every preview (#47), so everything built here has been unreachable from the public URL. Where only the owner can perform the check, say so on the issue and leave it open.
+
+## Divergence
+
+If the work cannot be done as the issue or brief states, stop. Write what was found and why the stated scope does not hold — the executor notes in `Docs/2026-09-01-handoff-public-surface-rest.md` are the model — hand it back, and do not improvise a different scope.
+
+## Where things live
+
+| What | Where |
+|---|---|
+| Open work | **GitHub Issues**, and nowhere else. A dated handoff or "shipped" record names issues; it never carries a task list |
+| Architecture and product plan | `Docs/consolidated-architecture.md` (rev. 6). §8 modules, §10 UI and identity, §11 phased plan, §12 execution prompts |
+| Decisions | `Docs/DECISIONS.md`, D-1 onward |
+| Feature intent | `Docs/intent/<feature>.md`, one per feature in flight: why, decisions with rejected alternatives, invariants, done |
+| Design direction | `Docs/consolidated-architecture.md` §10, enforced by `tests/public-surface-tokens.test.mjs` |
+| Dated records | `Docs/<date>-<slug>.md`: handoffs, shipped-on-a-day summaries, ADRs, scoping prompts. Written once, never edited |
+| Assets, content sources, costs | `Docs/asset-register.md`, `Docs/content-sources.md`, `Docs/costs.md` — living, edited in place |
+| AI module specs and skills | `AI/docs/specs/`, `AI/.claude/skills/` (loaded only for a session rooted in `AI/`) |
+
+The docs contract is: a file that will be updated again has a fixed, undated name and exactly one copy; a file that will not is dated and never edited. A dated name on a living file is the bug.
+
+## Sessions and branches
+
+One local session per repo at a time; parallel work goes to cloud sessions, each in its own clone. Cut every branch from `origin/main`, one branch per issue, and delete the branch when the PR merges. `.claude/settings.json` is committed and portable: permissions only, no absolute paths, no hooks. Per-machine hooks go in the gitignored `.claude/settings.local.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Docs/2026-09-01-handoff-public-surface-rest.md
+++ b/Docs/2026-09-01-handoff-public-surface-rest.md
@@ -1,3 +1,5 @@
+> **Record.** Executor handoff for the `ui/public-surface-rest` slice (D-63, 2026-09-01), moved from the repo root on 2026-09-03. Not updated again; open items named here live in GitHub Issues.
+
 # Notes for the orchestrator — `ui/public-surface-rest`
 
 Executor slice: finish the §10 palette migration across the rest of the PUBLIC surface, make the

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -3668,7 +3668,7 @@ this is the class of defect a pair table catches and a reviewer does not.
 on `/dashboard`, an authenticated surface this slice is scoped out of. Migrating it would have left
 a §10 board under a sky-blue hero beside a sky-blue `CheckInStatusPanel`, and fixing that means
 editing `src/app/dashboard/page.tsx` and `CheckInStatusPanel`, both hard-stop out of scope. It keeps
-its sky palette and is recorded in `NOTES-FOR-ORCHESTRATOR.md` instead.
+its sky palette and is recorded in `Docs/2026-09-01-handoff-public-surface-rest.md` (moved from `NOTES-FOR-ORCHESTRATOR.md` on 2026-09-03) instead.
 
 ---
 

--- a/Docs/intent/production-schema-apply.md
+++ b/Docs/intent/production-schema-apply.md
@@ -1,0 +1,45 @@
+# Intent — apply migrations 0011–0025 to production
+
+Living while the apply is pending. Records the decision state from `Docs/DECISIONS.md`
+D-41, D-74 and D-75 so that a session does not have to re-derive it. When production
+carries `0025`, this file becomes a dated record.
+
+## Why
+
+Production (`bwpguotjzczmieeepczf`) carries `0001`–`0010`. Migrations `0011`–`0025` are
+applied and verified on the preview branch `phase-3-4-staging` (D-75, 2026-09-02), and
+`0025` is a **security fix**: before it, `anon` and `authenticated` could execute all 18
+internal SECURITY DEFINER functions (D-74). Production remains exposed until `0025` is
+applied there. The live suites (`tests/live-rls.test.mjs`, `tests/live-definer-grants.test.mjs`)
+already prove the fix on preview; production is the only target where it is unproven.
+
+## Decisions
+
+| Decision | Rejected | Where |
+|---|---|---|
+| Nothing in the repo applies migrations; applying is a by-hand, owner-authorised act against a named ref | `supabase db push` in a script | `supabase/migrations/README.md`, D-21 |
+| Preview first, then production, same files, same order | Production-only hotfix for `0025` | D-41 pattern, D-75 |
+| The apply script refuses any connection string not naming the intended ref | Trusting the operator to paste the right URL | D-75 |
+| `0011`–`0025` go together and **must include `0025`** | Applying the feature migrations without the lockdown | D-75 |
+
+## Invariants
+
+- Migration headers change only in comments (`APPLIED:` and `TARGET:` lines); `sql-lint`'s
+  statement count stays at 489 and `tests/sql-migration-harness.test.mjs` stays green.
+- Monotonic rank: everything applied to production is also applied to preview, never the
+  reverse.
+- After the apply, anon/authenticated `execute` on the 18 D-74 functions reads 0 of 18 on
+  production, probed the way D-75 probed preview.
+
+## Definition of done
+
+Production has `0011`–`0025` applied, the post-apply probe reads 0 of 18, the headers
+read `APPLIED: production` with the date, `tests/live-definer-grants.test.mjs` has been run
+against production credentials once and is green, and D-76 records all of it.
+
+## Open questions
+
+- When the owner authorises the production apply (owner action; the guarded script from
+  D-75 is ready).
+- Whether `Temp/Sluglines/SECURITY-FINDING-definer-anon-grants.md` should be copied into
+  `Docs/` as a dated record before the apply, so the finding survives outside one machine.


### PR DESCRIPTION
## Summary

- The repo had no project context at all: no `CLAUDE.md`, no `AGENTS.md`, no `.claude/`. `AGENTS.md` now carries the stack, the six gates run as independent commands, the hard constraints the repo already enforces elsewhere (append-only migrations and `DECISIONS.md`, the production-ref refusal, content preservation from D-13, the §10 token gate, `AI/` isolation), a **definition of done** that requires deployed evidence (with the honest note that `sluglines.com` is still WordPress until #25 and #47), a **divergence** rule, and a map of where things live. `CLAUDE.md` is the one-line `@AGENTS.md` import so Claude Code, Codex and Hermes read the same file.
- `.claude/settings.json` is committed and portable: permissions only, deny `.env*` and the two scripts that write to a database.
- `NOTES-FOR-ORCHESTRATOR.md` was a 2026-09-01 executor handoff sitting undated at the repo root. It moves to `Docs/2026-09-01-handoff-public-surface-rest.md` as a record with a one-line header, and the single reference in `DECISIONS.md` (line 3671) follows it. That is the only edit to the append-only log.
- `Docs/intent/production-schema-apply.md` records the D-41/D-74/D-75 state: `0011`–`0025` are on preview, production is still exposed to D-74 until `0025` is applied there, and what closes it.

## Verification

No application code or SQL changed. `.claude/settings.json` parses; `AGENTS.md` is 55 lines. The gates were not run in this session; CI on this PR runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt9mffL3dyNTWxL6abya1X

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mt9mffL3dyNTWxL6abya1X)_