### PR TITLE
fix(tests): a skipped suite is SKIP, not PASS (A6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,52 @@ jobs:
 
       # tests/live-rls.test.mjs skips itself when .env.preview.local is absent, so the
       # suite is green here without database credentials and never targets production.
+      # A skip is reported as SKIP, not PASS (A6) — see the migration-live-check job
+      # below for the case where a skip here is not acceptable.
       - name: Run test suite
         run: npm run test
+
+  migration-live-check:
+    name: Live suites required for migration changes
+    runs-on: ubuntu-latest
+    # Only a pull request has a base to diff against; push/workflow_dispatch have
+    # no "other side" to compare, so there is nothing to gate here.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check whether this PR touches supabase/migrations
+        id: diff
+        run: |
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- supabase/migrations/ | grep -q .; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.diff.outputs.touched == 'true'
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.diff.outputs.touched == 'true'
+        run: npm ci --ignore-scripts
+
+      # A migration change is exactly the diff the live-* suites (live-rls,
+      # live-definer-grants, live-public-surface, live-rate-limit) exist to gate
+      # (A6): every live RLS assertion in the repo lives in this set. Without
+      # preview credentials configured as repo secrets, these suites SKIP rather
+      # than run — REQUIRE_NO_SKIPS turns that silent skip into a failed job
+      # instead of a migration PR merging on the strength of the static linter alone.
+      - name: Run live suites (must not skip on a migration PR)
+        if: steps.diff.outputs.touched == 'true'
+        env:
+          REQUIRE_NO_SKIPS: '1'
+        run: npm run test -- live-
 
   build:
     name: Next build

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -28,18 +28,32 @@ if (files.length === 0) {
   process.exit(1)
 }
 
+// A suite that has no preview credentials prints "<name>: SKIPPED — ..." and
+// exits 0 (see tests/live-*.test.mjs) rather than failing a checkout that has
+// never been pointed at a database. That is a legitimate outcome, but it is
+// not a pass: a skipped suite asserted nothing, and every live RLS assertion
+// in the repo lives in these four suites. Counting it toward PASS is exactly
+// how `npm test` went green while proving nothing about RLS (A6).
+const SKIP_MARKER = /:\s*SKIPPED\b/
+const requireNoSkips = process.env.REQUIRE_NO_SKIPS === '1'
+
 const failed = []
+const skipped = []
 
 for (const name of files) {
   const started = Date.now()
   const result = spawnSync(
     process.execPath,
     ['--experimental-strip-types', '--disable-warning=ExperimentalWarning', path.join(testDir, name)],
-    { cwd: root, stdio: 'inherit' },
+    { cwd: root, stdio: ['inherit', 'pipe', 'pipe'] },
   )
 
   const elapsed = Date.now() - started
   const code = result.status
+  const stdout = result.stdout?.toString() ?? ''
+  const stderr = result.stderr?.toString() ?? ''
+  process.stdout.write(stdout)
+  process.stderr.write(stderr)
 
   if (result.error) {
     failed.push(`${name} (${result.error.message})`)
@@ -50,12 +64,28 @@ for (const name of files) {
   } else if (code !== 0) {
     failed.push(`${name} (exit ${code})`)
     console.error(`FAIL ${name} — exit ${code}`)
+  } else if (SKIP_MARKER.test(stdout)) {
+    skipped.push(name)
+    console.log(`skip ${name} (${elapsed} ms)`)
   } else {
     console.log(`ok   ${name} (${elapsed} ms)`)
   }
 }
 
-console.log(`\nPASS=${files.length - failed.length} FAIL=${failed.length}`)
+const passed = files.length - failed.length - skipped.length
+console.log(`\nPASS=${passed} SKIP=${skipped.length} FAIL=${failed.length}`)
+
+if (skipped.length > 0) {
+  console.log(`\nSkipped files (no ok/fail verdict — see SKIPPED reason above):\n${skipped.map((entry) => `  - ${entry}`).join('\n')}`)
+}
+
+if (requireNoSkips && skipped.length > 0) {
+  console.error(
+    `\nREQUIRE_NO_SKIPS=1: ${skipped.length} suite(s) skipped instead of running. ` +
+      'This run must execute for real, not skip.'
+  )
+  process.exit(1)
+}
 
 if (failed.length > 0) {
   console.error(`\nFailing files:\n${failed.map((entry) => `  - ${entry}`).join('\n')}`)


### PR DESCRIPTION
## The problem

`npm run test` printed `PASS=49 FAIL=0`. Four of those suites never executed:

```
live-definer-grants: SKIPPED — no preview credentials.
live-public-surface: SKIPPED — no public credentials.
live-rate-limit:     SKIPPED — no preview credentials.
live-rls:            SKIPPED — no preview credentials.
```

They still reported `ok` and counted toward the 49.

**Every live RLS assertion in the repo is in that skipped set** — the control the architecture
document leans on hardest (D-28/D-30's "38 live RLS assertions"). A green `npm test` without preview
credentials proved nothing about the security posture. `sql:check` already states its own ceiling —
*"static shape check only -- this does not verify RLS behaviour"* — so the static gate and the live
gate are disjoint, and only the static one ran by default.

PR #111 is a concrete instance: an anon-execute hole that `live-definer-grants` exists to catch, in
a tree where that suite silently never ran.

## The change

```
PASS=45 SKIP=4 FAIL=0

Skipped files (no ok/fail verdict — see SKIPPED reason above):
  - live-definer-grants.test.mjs
  - live-public-surface.test.mjs
  - live-rate-limit.test.mjs
  - live-rls.test.mjs
```

- `scripts/run-tests.mjs` tracks skips separately; a skipped suite no longer reports `ok`.
- `.github/workflows/ci.yml`: a PR touching `supabase/migrations/**` **fails** if the live suites
  skipped. Action refs remain SHA-pinned (`tests/workflow-pinning.test.mjs` enforces).

## Verification

Output above is from the reviewer's own run, not the author's report.
`sql:check` 25 migrations / 0 violations; `build` 419 pages; typecheck clean.

🤖 Implemented by Claude Code, verified by Hermes.