### PR TITLE
docs: C3's SMS spend alarm names its instrument — a provider-side billing alert, not yet configured (D-81, #119)

### DIFF
--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -5292,3 +5292,78 @@ closes the gap between what D-13 promised and what actually happened.
 **Status:** ADOPTED. D-13 is narrowed to the M1–M4 core effective this entry. `AGENTS.md`'s opening
 paragraph is corrected in the same change (PR 1, `fix/public-surface-honesty`) to stop asserting the
 whole application core is rebuilt-not-transplanted.
+
+---
+
+## D-81 — C3's instrument is a provider-side billing/usage alert, not the §13 `manual_metrics` path. Issue #119
+
+**Date:** 2026-09-05
+
+### The decision
+
+`Docs/costs.md` C3 sets an alarm threshold of 500 SMS sends/day. The instrument that watches that
+threshold is a **provider-side billing/usage alert configured at the SMS provider account** — not
+the rev. 5.3 §13 path of `manual_metrics.sms_sends` joining `metrics_weekly` for display on a
+moderator dashboard. The `manual_metrics`/`metrics_weekly`/moderator-dashboard machinery is **not
+built for this cap** and this entry does not open building it.
+
+### The evidence that there is no instrument today
+
+- `manual_metrics` exists in this repo only as a comment —
+  `supabase/migrations/0001_rebuild_foundation.sql:26` lists it alongside `product_events` and
+  `metrics_weekly` as a future §8 M10 concern, not as a table. There is no migration that creates it.
+- D-11 item 1 already assigned the real work — `0025_product_events.sql` (+ `manual_metrics`,
+  `metrics_weekly`) — **DEFERRED**, on the grounds that numbering a migration `0025` would imply a
+  sequence that did not exist yet in this repo. That reasoning no longer even applies unmodified:
+  the ordinal is now taken by a different, shipped file, `0025_lock_down_definer_functions.sql`
+  (D-74/D-77, applied to production). Reusing D-11's plan would require renumbering past `0025`
+  under a name that already means something else on production.
+- `metrics_weekly` does not exist anywhere in this repo — no migration, no schema reference outside
+  `Docs/consolidated-architecture.md`'s own description of the never-built table.
+- There is no `/moderator` route under `src/app/` — the string "moderator" appears only in
+  `src/app/dashboard/page.tsx` and `src/app/api/agent/route.ts` as ordinary prose/identifiers, not as
+  a route segment. rev. 5.3 §13's "alarm rows on the moderator dashboard" has no dashboard to put a
+  row on.
+
+### The rejected alternative, and why
+
+Building `manual_metrics` + `metrics_weekly` + a moderator-facing surface to display one weekly
+integer is a large amount of schema, RLS and UI machinery for a single number during a pilot with no
+SMS provider integrated yet (C3's own Measurement row in `Docs/costs.md` has said this since D-9).
+Being in-repo, that machinery is also something a bug or a bad migration in *this* repo could break
+or silence without anyone noticing until the weekly review runs. A provider-side account alert needs
+no code here at all: it lives at the SMS provider, fires independent of anything this repo's next
+commit does, and cannot be defeated by a regression in `sluglines`. For a threshold whose entire job
+is catching abuse of a public endpoint, an instrument outside the abuse surface is the stronger
+property, not just the cheaper one.
+
+### Why C3 is treated differently from C1/C2
+
+C1 and C2 are both model-spend alarms, and model spend already has a hard backstop: C4
+(`src/lib/ai/cost.ts`'s `PER_TURN_COST_CEILING_USD`, enforced mid-loop by `src/lib/ai/agent.ts`, D-65)
+stops a runaway turn before it can spend past a fixed ceiling, so an unmonitored C1/C2 degrades
+gracefully to "found out at invoice time" rather than to unbounded spend. C3 has no such backstop.
+`POST /api/auth/send-otp` is a public, unauthenticated endpoint that spends real money — an SMS
+send — per request, gated only by the §8 M2 abuse controls (resend cooldown, verify-attempt caps,
+per-IP daily send cap, CAPTCHA) that `Docs/costs.md`'s C3 note already describes as bounding the
+abuse rather than eliminating it. §14 risk 11 (SMS-pumping) names this as an automated,
+financially-motivated attack, not a hypothetical. A cap that bounds a live, adversarial, per-request
+cost with no hard stop behind it is exactly the one that should not sit on an unverified "PENDING"
+instrument indefinitely — hence recording the instrument now, even before it is configured.
+
+### What this entry does not claim
+
+**This is a documentation decision, not a working alarm.** No SMS provider is integrated in this
+repo yet, so there is nothing to configure the alert against, and configuring the alert and
+test-firing it are owner actions at an external provider account — neither can be done from a
+session in this repo. C3 is not enforced, wired, or done by this entry. Nothing under `src/`,
+`supabase/`, or `tests/` changes.
+
+**Status:** PENDING. The decision made here is *which* instrument C3 uses, not that the instrument
+exists. This entry moves to DONE when the provider-side alert is configured at 500 sends/day and has
+been test-fired, with that evidence (date, provider, what was observed) recorded on issue #119 —
+per `AGENTS.md`'s Definition of Done, an owner-only check that stays open until someone states they
+performed it. Issue #119 must close **before or with** issue #52, never after: #52 is what gives
+`POST /api/auth/send-otp` the ability to send a real SMS at all (this repo has no provider wired in
+yet), and an endpoint that can spend money without any account-level alarm watching it is the
+precise gap this entry exists to close before it opens.

--- a/Docs/costs.md
+++ b/Docs/costs.md
@@ -16,7 +16,7 @@ value instead of inventing one at the moment a gate is evaluated.
 |---|---|---|---|---|
 | C1 | Model spend per assistant turn | **≤ $0.10 / turn** | Alarm threshold | rev. 5.3 §11 Phase 5 — the AI verification gate checks per-turn cost against this file |
 | C2 | Model spend per month | **≤ $50 / month** | Alarm threshold | rev. 5.3 §13 "Spend"; surfaced as an alarm row on the moderator dashboard |
-| C3 | SMS sends per day | **500 sends / day** | Alarm threshold | rev. 5.3 §8 M2 / §13; bounds SMS-pumping abuse (risk 11) |
+| C3 | SMS sends per day | **500 sends / day** | Alarm threshold | rev. 5.3 §8 M2 / §13; bounds SMS-pumping abuse (risk 11); instrument is a provider-side billing/usage alert, not built yet — `Docs/DECISIONS.md` D-81 |
 | C4 | Model spend per assistant turn, hard stop | **≤ $0.15 / turn** | **Hard cap (enforced)** | issue #56; `src/lib/ai/cost.ts` `PER_TURN_COST_CEILING_USD`, checked mid-loop by `src/lib/ai/agent.ts` |
 | C5 | Assistant turns per member per day | **40 turns/member/day** | **Hard cap (enforced)** | issue #56; `0011`'s `ai_member_turn_count_today()`, checked before any model call |
 | C6 | Assistant turns, globally, per day | **2,000 turns/day** | **Hard cap (enforced)** | issue #56; `0011`'s `ai_global_turn_count_today()`, checked before any model call |
@@ -39,7 +39,10 @@ value instead of inventing one at the moment a gate is evaluated.
   cost-sheet alarm **two months running**.
 - **C3 (500 sends/day)** pairs with the §8 M2 OTP abuse controls (resend cooldown, verify-attempt
   caps, per-IP daily send cap, CAPTCHA). The caps bound the abuse; this alarm detects when the
-  bound is being tested.
+  bound is being tested. **The instrument is a provider-side billing/usage alert configured at the
+  SMS provider account** — not the §13 `manual_metrics`/`metrics_weekly`/moderator-dashboard path,
+  which is not built for this cap (`Docs/DECISIONS.md` D-81). **It is not yet configured**: no SMS
+  provider is integrated in this repo, so there is no account to configure it at.
 - **C4/C5/C6** are new pilot defaults recorded by issue #56 (Docs/DECISIONS.md D-65), the first caps
   in this table with an actual instrument behind them (see "Measurement" below). The two volume caps
   (C5, C6) are read from `agent_traces` via two SECURITY DEFINER functions in `0011`, checked before
@@ -61,7 +64,7 @@ value instead of inventing one at the moment a gate is evaluated.
 |---|---|---|
 | C1 | Per-turn cost recorded by the agent runtime / `agent_traces` | **RECORDED, not gated** — `agent_traces.estimated_cost_usd` (`0011`) is populated by every turn; nothing reviews it against C1 automatically yet, which is the human half of "alarm" |
 | C2 | `manual_metrics.model_cost_cents`, recorded weekly from the provider invoice | **PENDING** — `manual_metrics` table not created (deferred, see `Docs/DECISIONS.md` D-11) |
-| C3 | `manual_metrics.sms_sends`, recorded weekly from the provider dashboard | **PENDING** — no SMS provider integrated; SMS is Phase 5 |
+| C3 | Provider-side billing/usage alert at the SMS provider account (`Docs/DECISIONS.md` D-81) | **PENDING** — instrument is now chosen, not merely unspecified, but no SMS provider is integrated and the alert is not configured or test-fired |
 | C4 | Per-turn cost, enforced mid-loop | **ENFORCED** — `src/lib/ai/agent.ts`, from `response.usage` against `src/lib/ai/cost.ts`'s rate table |
 | C5 | Per-member daily turn count | **ENFORCED** — `0011`'s `ai_member_turn_count_today()` |
 | C6 | Global daily turn count | **ENFORCED** — `0011`'s `ai_global_turn_count_today()` |
@@ -92,3 +95,4 @@ These are provisional and expected to change once real usage data exists. When a
 |---|---|---|
 | 2026-08-14 | Initial provisional caps C1–C3 recorded. | rev. 5.3 §11 Phase 0 |
 | 2026-09-02 | C1 corrected from "hard cap" to "alarm threshold" (it never had an instrument to be a hard cap with). Added C4 (≤$0.15/turn hard stop), C5 (40 turns/member/day) and C6 (2,000 turns/day), all enforced by the AI runtime transplant. | issue #56, Docs/DECISIONS.md D-65 |
+| 2026-09-05 | C3's instrument named as a provider-side billing/usage alert at the SMS provider account, not the §13 `manual_metrics`/`metrics_weekly`/moderator-dashboard path. Value unchanged (500 sends/day); status remains PENDING — the alert is not yet configured or test-fired. | issue #119, Docs/DECISIONS.md D-81 |


### PR DESCRIPTION
**Does not close #119.** This records which instrument C3 uses; it does not deliver a working alarm. The issue stays open until the alert exists and has been test-fired — as the issue itself says, an untested alarm is not an alarm.

## What the issue found

`Docs/costs.md` C3 sets a threshold of **500 SMS sends / day**. Nothing counts SMS sends, nothing stores a count, and nothing fires. The rev. 5.3 §13 path it was meant to use does not exist:

- **`manual_metrics`** — appears in this repo only as a comment at `supabase/migrations/0001_rebuild_foundation.sql:26`. No migration creates it. D-11 deferred the work, and the `0025` ordinal §12 P0 assigned it to is now taken by a different shipped file, `0025_lock_down_definer_functions.sql` (D-74/D-77, applied to production).
- **`metrics_weekly`** — does not exist anywhere outside the architecture document's description of it.
- **`/moderator`** — no such route under `src/app/`. §13's "alarm row on the moderator dashboard" has no dashboard to put a row on.

So C3 has been an alarm threshold with no counter, no store, and no surface.

## The decision (owner, this session)

C3's instrument is a **provider-side billing/usage alert configured at the SMS provider account**, not the §13 `manual_metrics` / `metrics_weekly` / moderator-dashboard path.

The rejected alternative and why: building that machinery to surface one weekly integer is disproportionate for a pilot with no SMS provider integrated. Being in-repo, it could also be broken or silenced by a regression in this repo without anyone noticing until the weekly review. An account-level provider alert needs no code here, fires independently of what this repo ships next, and cannot be defeated by a bug in the very surface it is watching.

## What this PR changes

- **`Docs/DECISIONS.md`** — appends **D-81** (append-only respected): the decision, the evidence that no instrument exists today, the rejected alternative, and why C3 is treated differently from C1/C2 — model spend has the C4 hard stop behind it, whereas `POST /api/auth/send-otp` is a public unauthenticated endpoint that spends real money per request, and SMS-pumping is §14 risk 11.
- **`Docs/costs.md`** (living document, edited in place) — the C3 row, the C3 note, and the C3 Measurement row now name the instrument. The value is unchanged at 500 sends/day. One dated changelog row appended.

**No file under `src/`, `supabase/` or `tests/` changes.**

## The status is deliberately PENDING, not ADOPTED

D-81 is recorded as **PENDING**, and every place the instrument is named also states it is **not yet configured**. Configuring and test-firing the alert are owner actions at an external provider, and no SMS provider is integrated yet.

D-81 states exactly what moves it to DONE: the alert configured at 500 sends/day and **test-fired**, with evidence on #119. It also records the ordering constraint from the issue — #119 must close **before or with #52**, never after, because #52 is what makes the endpoint able to spend money at all. Today the endpoint returns 503 (`phone_provider_disabled`), so exposure is nil; the moment #52 flips, an endpoint that spends money would otherwise run with no spend visibility.

`Docs/costs.md`'s existing sentence "C1/C2/C3 remain recorded-not-enforced as this file originally stated" is left intact and remains true.

## Gates — six, run separately, verified by the orchestrator in the worktree

| Gate | Result |
|---|---|
| `npm run test` | **PASS=49 SKIP=4 FAIL=0** (the 4 skips are `live-*`, no preview credentials) |
| `npm run lint` | 0 errors, 2 pre-existing warnings |
| `npm run typecheck` | clean |
| `npm run build` | succeeds |
| `npm run sql:check` | 25 migrations, 489 statements, 0 violations |
| `npm run e2e` | 36/36 passed |

Re-run independently rather than accepted from the executor's self-report. `tests/baseline-n.test.mjs` passes unchanged — no test added or removed.

## Owner action to actually close #119

1. Choose/confirm the SMS provider account that will send OTPs.
2. Configure a usage or billing alert at **500 sends/day**.
3. **Test-fire it** and confirm the notification arrives.
4. Post the evidence on #119, then flip D-81 to DONE in a follow-up.

Related: #119, #52 (must not close after this), #56 / D-65 (bounded AI spend, the C4/C5/C6 precedent), architecture §13 "Spend" and §14 risk 11.
