### PR TITLE
docs: dated record of what shipped on 2026-09-06 and what stays open

### DIFF
--- a/Docs/2026-09-06-shipped.md
+++ b/Docs/2026-09-06-shipped.md
@@ -1,0 +1,89 @@
+# Shipped — 2026-09-06
+
+**Status:** RECORD. One session's merges as they stood at close; not updated afterwards. Every
+piece of open work named here lives in the issue tracker, which is where it changes.
+**Recorded:** 2026-09-06, at `226287f`.
+**Repo:** `sluglines`. **Production:** `bwpguotjzczmieeepczf`, migrations `0001`–`0026` applied;
+`0027`–`0030` written, not applied (D-83, D-87, D-88, D-89).
+
+---
+
+## What this session was
+
+A takeover of the review session that produced issues #132–#145. It landed the clean baseline
+(#131), then worked the review's tiers one issue per branch, one branch per PR, every branch cut
+from `origin/main`, and finally merged the whole train into `main` in the order the tiers implied,
+bringing `main` into each branch before it merged rather than rebasing anything.
+
+Fifteen PRs merged: #131, #147, #149, #150, #151, #152, #153, #154, #155, #156, #157, #158, #159,
+#146, #161. Fourteen decisions recorded: D-82 to D-95. Baseline N moved from 53 files / 1,688
+assertion call sites to **56 / 2,070**, and `tests/baseline-n.test.mjs` agrees with the header at
+every step.
+
+## The merges
+
+| PR | Issue | Decision | What it is |
+|---|---|---|---|
+| #147 | #132 | D-82 | The pilot corridor's location ids resolved by slug per request; 23503 is a 422 |
+| #149 | #133 | D-83 | `offer_cancel` is the poster's or a moderator's — `0027`, written not applied |
+| #150 | #134 | D-84 | `/board` paints its own light shell, formats in Eastern time; branded 404; both axe-gated |
+| #151 | #135 | D-85 | Check-in from the spot page through `presence_checkin`; Board and Sign in in the nav |
+| #152 | #136 | D-86 | `next` carried through sign-in; onboarding once; phone out of the URL; `/dashboard` degrades; root `error.tsx` |
+| #153 | #137 | D-87 | `offer_create` bounds and per-member cap, `offers` indexes — `0028`, written not applied |
+| #154 | #138 | D-88 | `report_no_show` from ARRIVING, five a day, subject-readable — `0029`, written not applied |
+| #155 | #139 | D-89 | `create_recurring_offer` validates the timezone; the sweep isolates each template — `0030`, written not applied |
+| #156 | #140 | D-90 | Open offers first, "Yours" with cancel and release, leaving-in presets, live list |
+| #157 | #141 | D-91 | Keyboard About menu, 3:1 control borders, target sizes, one `main`, skip link, reduced motion |
+| #158 | #142 | D-92 | README, `/app` qualifier, footer, home title, blog/news split, `Docs/intent` |
+| #159 | #144 | D-93 | `unavailable` outcomes logged without PII, rate-limit eviction, typed service-role error |
+| #146 | — | — | Dependabot: `@types/react-dom` 19.2.7, `postcss` 8.5.27 |
+| #161 | #160 | D-95 | Spot imagery through `next/image`'s server half only; script budget back to 176 KiB |
+
+Each PR passed the six gates locally on its merged head before its push, and all of its
+credential-free CI checks before its merge. The `Live suites required for migration changes` job
+was red on #149, #153, #154 and #155 for the reason recorded on each: it ran no test, because the
+preview credentials from #41 do not exist (#145, item 2).
+
+## What the train taught, in the order it was learned
+
+- **The gates caught three interactions between PRs that were individually green.** The
+  leaving-in preset buttons from #140 carried the 1.5:1 border #141 outlawed; the footer #142
+  rewrote dropped the About links #141 needs reachable without JavaScript; the corridor-miss branch
+  #132 added returned `unavailable` without the log line #144 requires. Each was reconciled in the
+  later PR under the later PR's rule, and each is now pinned by the test that caught it.
+- **The Lighthouse script budget did its job twice.** #152 merged onto #151 tipped `/spots/[slug]`
+  1,396 bytes over D-64's 176 KiB. D-94 raised the budget to 184 KiB with CI's own figures, named
+  what it found (#160) and committed to lowering it back. Reading the RSC payload while fixing #160
+  showed the sharper cause — `next/image`'s entry module requires the client component at top level,
+  so any server-side import of it ships the runtime on every page rendering the importing component,
+  diagram or no diagram — and D-95 removed the import from the public surface, took 8,868 bytes off
+  the spot page in CI's measurement, and put the budget back at 180,224 with 7,277 bytes to spare.
+- **Two CodeQL findings were fixed before merge** rather than argued with: a
+  partial regex escape in `tests/offer-state-machine.test.mjs`, an unused assignment in
+  `tests/live-rls.test.mjs`.
+- **Stacked migration PRs cost a retarget each.** #153, #154 and #155 were opened against each other
+  to keep ordinals contiguous; CI does not run on a non-`main` base, so each was retargeted to `main`
+  after its parent merged, merged with `main`, and only then checked.
+
+## What stays open, and why it is not this session's to close
+
+- **#132–#142, #144** stay open under `AGENTS.md`'s definition of done: each closes when a person
+  has seen it working at the deployed URL, and every preview is behind Vercel Authentication (#47)
+  while `sluglines.com` is still the WordPress site (#25). The evidence a session can produce is on
+  each PR and each decision.
+- **`0027`–`0030`** are written, linted and covered, and not applied anywhere. Applying them is an
+  owner-authorised act against a named target; D-83, D-87, D-88 and D-89 say what closes them.
+- **#143** was handed back with a proposal rather than built as stated (its stated fix would hide the
+  board from members without a home spot). **#148** (a rider's own withdrawal of a CONFIRMED seat)
+  was filed from D-83's gap. **#160** carries D-95's measurement and can close on the owner's review.
+- **#145** is the owner-only list: the 14 stale branches from #131, preview secrets (#41), the D-74
+  forensic query, PITR (#49), phone auth (#52, #118, #120), sweeps (#109), DNS (#25).
+
+## Branches
+
+Every branch this session pushed is merged and deleted locally. The remote refuses ref deletion
+from the session credential (tried twice; #145 records the same), so the thirteen merged `fix/…` heads,
+`fix/132-corridor-location-ids` through `fix/160-spot-photo-image-props`, and Dependabot's
+`dependabot/npm_and_yarn/dev-dependencies-791a924a8d` remain on the remote for the owner to delete
+with the stale fourteen, or for **Settings → General → Automatically delete head branches** to
+prevent next time.


### PR DESCRIPTION
Adds `Docs/2026-09-06-shipped.md`, the dated record the docs contract asks for at the close of a session: the fifteen PRs merged today (#131, #147, #149–#159, #146, #161), the decisions they carry (D-82 to D-95), what the merge train surfaced (three cross-PR interactions the gates caught, the budget's D-94 → D-95 arc, two CodeQL fixes, the stacked-migration retargets), and what stays open with the issue that owns each item. It names issues; it carries no task list.

No code changes. Baseline N is unchanged at 56 / 2,070.

## Gates, run separately

| gate | result |
|---|---|
| `npm run test` | 52 pass, 4 live-* skip, 0 fail |
| `npm run lint` | 0 errors, 2 pre-existing warnings |
| `npm run typecheck` | pass |
| `npm run build` | pass |
| `npm run sql:check` | 30 migrations, 564 statements, 0 violations |
| `npm run e2e` | 40 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZsDzZnpuCp54vEehKi1g2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZsDzZnpuCp54vEehKi1g2)_